### PR TITLE
feat: The Bridgekeeper's Primer — adaptive teaching game

### DIFF
--- a/primer/README.md
+++ b/primer/README.md
@@ -8,7 +8,14 @@ repo's history.
 Inspired by the Young Lady's Illustrated Primer (Diamond Age): a scripted arc
 with a live tutor — "the ractor" — behind it.
 
-## Run it
+## Play it
+
+The static build is published at **https://primer.imagineering.cc** (and the
+Mautrix Galaxy at https://primer.imagineering.cc/land). That's degraded mode —
+see below — because the adaptive ractor needs a local Claude Code login.
+Deployed via `imagineering-infra`: `./scripts/deploy-to.sh <ip> primer`.
+
+## Run it (full, with the live ractor)
 
 ```bash
 node primer/server.mjs

--- a/primer/README.md
+++ b/primer/README.md
@@ -1,0 +1,42 @@
+# The Bridgekeeper's Primer
+
+A chat-shaped teaching game about how the superbridge works — plumbing vs portal
+rooms, the mautrix bridgev2 "megabridge", the Telegram receiver-lock, the relay
+appservice, and loop prevention. Every puzzle re-enacts a real gotcha from this
+repo's history.
+
+Inspired by the Young Lady's Illustrated Primer (Diamond Age): a scripted arc
+with a live tutor — "the ractor" — behind it.
+
+## Run it
+
+```bash
+node primer/server.mjs
+# open http://127.0.0.1:7777
+```
+
+The server shells out to headless Claude Code (`claude -p`, Max plan — no API
+key) with read-only repo tools and web search. That powers two adaptive layers:
+
+- **🪶 Ask the Primer** — a free-question box available throughout play. The
+  Primer greps `relay/appservice/`, reads `CLAUDE.md`/`superbridge.sh`, and
+  searches the mautrix docs before answering, in character.
+- **Generated chapters** — after the scripted arc (Chapters I–VI), the Primer
+  writes Chapter VII, VIII, … live: new scenes in the game's own step format
+  (choices, command inputs, badges), adapted to the mistakes you made and any
+  topic you request (double puppeting, reply threading, media relay…).
+
+## Degraded mode
+
+Opening `index.html` directly (no server) still works — you get the static
+six-chapter arc; the adaptive layer stays dark ("ractor offline").
+
+## Architecture
+
+| File | Role |
+|---|---|
+| `index.html` | Single-file game: chat UI, step engine, learner model, ractor hooks |
+| `server.mjs` | Zero-dependency Node server: serves the game, bridges `/api/ask` and `/api/chapter` to `claude -p` (tools: `Read,Grep,Glob,WebSearch,WebFetch`, cwd = repo root) |
+
+Generated chapters arrive as JSON arrays of engine steps and are spliced into
+the running script — the game's structure is mutable at play time by design.

--- a/primer/index.html
+++ b/primer/index.html
@@ -290,7 +290,7 @@
 <header>
   <h1>⛩ The Bridgekeeper's Primer</h1>
   <span class="subtitle">A Young Imagineer's Illustrated Guide to the Superbridge</span>
-  <a href="/land" style="font-size:0.74rem; color:#b9a5f5; text-decoration:none; border:1px solid #6a4fc4; border-radius:999px; padding:5px 14px;">🌌 Mautrix Galaxy</a>
+  <a href="land.html" style="font-size:0.74rem; color:#b9a5f5; text-decoration:none; border:1px solid #6a4fc4; border-radius:999px; padding:5px 14px;">🌌 Mautrix Galaxy</a>
   <button id="ractor-btn">🎭 Summon the Ractor</button>
   <div id="badges"></div>
 </header>

--- a/primer/index.html
+++ b/primer/index.html
@@ -260,6 +260,29 @@
   }
   #victory .scroll h3 { color: var(--matrix); font-size: 0.9rem; margin: 12px 0 4px; }
   #victory .scroll code { background: #0b0d12; padding: 1px 6px; border-radius: 5px; color: #9fe8c8; }
+
+  /* Voice ractor — summon button + audio-reactive sigil */
+  #ractor-btn {
+    display: none;
+    background: var(--panel2);
+    border: 1px solid #6a4fc4;
+    color: #b9a5f5;
+    border-radius: 999px;
+    padding: 5px 14px;
+    font-size: 0.74rem;
+    cursor: pointer;
+    font-family: inherit;
+  }
+  #ractor-btn:hover { background: #251d3a; }
+  #ractor-btn.live { border-color: var(--gold); color: var(--gold); }
+  #sigil {
+    display: none;
+    position: fixed;
+    top: 86px;
+    right: 18px;
+    z-index: 6;
+    pointer-events: none;
+  }
 </style>
 </head>
 <body>
@@ -267,8 +290,10 @@
 <header>
   <h1>⛩ The Bridgekeeper's Primer</h1>
   <span class="subtitle">A Young Imagineer's Illustrated Guide to the Superbridge</span>
+  <button id="ractor-btn">🎭 Summon the Ractor</button>
   <div id="badges"></div>
 </header>
+<canvas id="sigil" width="120" height="120"></canvas>
 <div id="room-bar">
   📍 <b id="room-name">#admins:imagineering.cc</b> <span id="room-desc"></span>
   <span id="ractor-light" class="off">○ ractor offline — static lessons only</span>
@@ -517,7 +542,7 @@ function el(html) { const d = document.createElement("div"); d.innerHTML = html;
 function scroll() { chatEl.scrollTop = chatEl.scrollHeight; }
 function esc(s) { return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;"); }
 
-function addMsg(platform, sender, text, extraClass = "") {
+function addMsg(platform, sender, text, extraClass = "", opts = {}) {
   const tag = { primer: "PRIMER", matrix: "MATRIX", discord: "DISCORD", telegram: "TELEGRAM",
                 whatsapp: "WHATSAPP", signal: "SIGNAL", error: "!", you: "YOU" }[platform] || platform;
   const node = el(
@@ -527,7 +552,16 @@ function addMsg(platform, sender, text, extraClass = "") {
      </div>`);
   chatEl.appendChild(node);
   scroll();
+  // The voice ractor performs every Primer line aloud (feedback, hints, badges)
+  // unless explicitly silenced (status spinners, lines the engine speaks itself).
+  if (voice.on && platform === "primer" && !opts.silent) voice.enqueue(stripHtml(text));
   return node;
+}
+
+function stripHtml(s) {
+  const d = document.createElement("div");
+  d.innerHTML = String(s);
+  return d.textContent.trim();
 }
 
 function next() { i++; run(); }
@@ -552,12 +586,14 @@ function run() {
   if (i >= S.length) return;
   const s = S[i];
   controlsEl.innerHTML = "";
+  voice.setScene(null);   // each interactive step re-registers itself below
 
   switch (s.t) {
     case "chapter":
       currentChapter = s.title;
       chatEl.appendChild(el(`<div class="chapter-rule">${s.title}</div>`));
       scroll();
+      if (voice.on) voice.enqueue(s.title);
       setTimeout(next, 700);
       break;
 
@@ -568,12 +604,16 @@ function run() {
       break;
 
     case "msg":
-      addMsg(s.platform, s.sender, s.text);
-      setTimeout(next, s.ms || 850);
+      addMsg(s.platform, s.sender, s.text, "", { silent: true });
+      // Voice mode: the Primer's own lines pace the game — the engine waits
+      // for the performance to finish. The world's messages keep their timers.
+      if (voice.on && s.platform === "primer") voice.speakAndWait(stripHtml(s.text)).then(next);
+      else setTimeout(next, s.ms || 850);
       break;
 
     case "choice": {
       const box = el(`<div class="choices"><div class="prompt">⚖ ${s.prompt}</div></div>`);
+      const buttons = [];
       s.options.forEach(o => {
         const b = el(`<button class="opt">${esc(o.label)}</button>`);
         b.onclick = () => {
@@ -587,9 +627,16 @@ function run() {
             addMsg("primer", "The Primer", "❌ " + o.fb);
           }
         };
+        buttons.push(b);
         box.appendChild(b);
       });
       controlsEl.appendChild(box);
+      voice.setScene({
+        kind: "choice",
+        prompt: s.prompt,
+        options: s.options.map(o => o.label),
+        choose: n => buttons[n - 1]?.click(),
+      });
       break;
     }
 
@@ -613,6 +660,19 @@ function run() {
       };
       box.appendChild(go);
       controlsEl.appendChild(box);
+      voice.setScene({
+        kind: "multi-select",
+        prompt: s.prompt,
+        options: s.options.map(o => o.label),
+        apply: indices => {
+          // Reset to the spoken selection, then apply.
+          s.options.forEach((o, n) => {
+            const want = indices.includes(n + 1);
+            if (state.get(o) !== want) box.children[n + 1].click();  // children[0] is the prompt
+          });
+          go.click();
+        },
+      });
       break;
     }
 
@@ -641,6 +701,12 @@ function run() {
       box.appendChild(row);
       controlsEl.appendChild(box);
       inp.focus();
+      voice.setScene({
+        kind: "command-input",
+        prompt: s.prompt,
+        hint: stripHtml(s.hint || ""),
+        type: text => { inp.value = text; submit(); },
+      });
       break;
     }
 
@@ -704,7 +770,8 @@ function primerGate() {
     const topic = inp.value.trim();
     go.disabled = true; inp.disabled = true;
     const thinking = addMsg("primer", "The Primer",
-      `<span class="thinking">Researching${topic ? " “" + esc(topic) + "”" : ""} — reading relay/appservice/, consulting docs.mau.fi</span>`);
+      `<span class="thinking">Researching${topic ? " “" + esc(topic) + "”" : ""} — reading relay/appservice/, consulting docs.mau.fi</span>`, "", { silent: true });
+    if (voice.on) voice.enqueue("Give me a few minutes — I am in the library, reading the relay's own source. The page will turn itself when the ink dries.");
     try {
       const r = await fetch("/api/chapter", {
         method: "POST",
@@ -726,6 +793,12 @@ function primerGate() {
   row.appendChild(inp); row.appendChild(go);
   box.appendChild(row); box.appendChild(skip);
   controlsEl.appendChild(box);
+  voice.setScene({
+    kind: "chapter-gate",
+    prompt: "The Primer offers to research and write a brand-new chapter, adapted to the learner — or finish with the field notes.",
+    write: topic => { inp.value = topic || ""; go.click(); },
+    finish: () => skip.click(),
+  });
 }
 
 /* ---- Ask-the-Primer dock (live whenever the server is up) ----------- */
@@ -741,7 +814,7 @@ document.getElementById("ask-send").onclick = async () => {
   askPanel.style.display = "none";
   learner.questions.push(q);
   addMsg("you", "@nick", esc(q));
-  const thinking = addMsg("primer", "The Primer", `<span class="thinking">Searching the repo and the wider web</span>`);
+  const thinking = addMsg("primer", "The Primer", `<span class="thinking">Searching the repo and the wider web</span>`, "", { silent: true });
   try {
     const r = await fetch("/api/ask", {
       method: "POST",
@@ -751,11 +824,377 @@ document.getElementById("ask-send").onclick = async () => {
     const data = await r.json();
     if (data.error) throw new Error(data.error);
     thinking.querySelector(".body").innerHTML = data.html;
+    if (voice.on) voice.enqueue(stripHtml(data.html));
   } catch (e) {
     thinking.querySelector(".body").innerHTML = "⚠ I could not reach my library: " + esc(e.message);
   }
   scroll();
 };
+
+/* ====================================================================
+   THE VOICE RACTOR — high-quality voice-to-voice via OpenAI Realtime.
+
+   Two-brain design: gpt-realtime PERFORMS the Primer (narration, listening,
+   sub-second banter, voice "sage") while headless Claude remains the scholar —
+   the realtime model's consult_library tool calls /api/ask, so repo-grounded
+   research arrives as a script for the voice to perform.
+
+   The model also gets tools that operate the game's own buttons
+   (answer_choice / answer_multi / type_command / request_chapter), so saying
+   "the second one" or speaking a command plays the game. Session/token/audio
+   plumbing follows embodied-dreamfinder (the proven local reference).
+   ==================================================================== */
+const VOICE_SAMPLE_RATE = 24000;
+const VOICE_MODEL = "gpt-realtime";
+const VOICE_NAME = "sage";
+
+const VOICE_INSTRUCTIONS = `You are THE PRIMER — the living voice of "The Bridgekeeper's Primer",
+an interactive game teaching how the imagineering.cc Matrix superbridge works: plumbing vs
+portal rooms, the mautrix bridgev2 "megabridge", split portals and receivers, the relay
+appservice with puppet users, and loop prevention.
+Voice: warm, slightly mythic, precise — the Illustrated Primer from The Diamond Age crossed
+with a senior infrastructure engineer. Never condescending.
+Rules:
+- A message marked NARRATION is a line from the book: perform it aloud VERBATIM — do not add,
+  drop, or reorder words. Speak notation naturally ("PL 50" as "power level fifty",
+  "!tg" as "bang T G").
+- Everything else: 1-2 SHORT sentences maximum. This is a live voice conversation.
+- SCENE messages describe what is on the learner's screen. When the learner answers a puzzle
+  aloud ("the second one", "power level fifty", or speaking a command like "discord set relay"),
+  call the matching tool: answer_choice / answer_multi / type_command. The game gives its own
+  feedback — add at most a brief phrase.
+- For deep questions about the bridge code or mautrix, FIRST say you are consulting the
+  library, THEN call consult_library (it takes a minute or two — reassure the learner).
+  Perform its answer faithfully in your own voice.
+- Never guess the screen state: call get_scene if unsure.`;
+
+const VOICE_TOOLS = [
+  { type: "function", name: "get_scene",
+    description: "Returns the current on-screen prompt and options, as JSON.",
+    parameters: { type: "object", properties: {} } },
+  { type: "function", name: "answer_choice",
+    description: "Answer the current multiple-choice puzzle. 1-based index.",
+    parameters: { type: "object", properties: { index: { type: "integer" } }, required: ["index"] } },
+  { type: "function", name: "answer_multi",
+    description: "Answer the current select-all puzzle with ALL chosen options (1-based indices), then apply.",
+    parameters: { type: "object", properties: { indices: { type: "array", items: { type: "integer" } } }, required: ["indices"] } },
+  { type: "function", name: "type_command",
+    description: "Type the learner's spoken command into the current command-input puzzle and submit it. Render spoken commands into literal syntax (e.g. 'bang discord set relay' → '!discord set-relay').",
+    parameters: { type: "object", properties: { text: { type: "string" } }, required: ["text"] } },
+  { type: "function", name: "consult_library",
+    description: "Deep research: a scholar (Claude) greps this repository's relay source and searches the mautrix docs. Takes 1-2 minutes — warn the learner aloud BEFORE calling. Returns text to perform.",
+    parameters: { type: "object", properties: { question: { type: "string" } }, required: ["question"] } },
+  { type: "function", name: "request_chapter",
+    description: "At a chapter gate only: ask the book to research and write the next chapter. Optional topic.",
+    parameters: { type: "object", properties: { topic: { type: "string" } } } },
+  { type: "function", name: "finish_game",
+    description: "At a chapter gate only: end the game and show the field notes.",
+    parameters: { type: "object", properties: {} } },
+];
+
+const voice = {
+  on: false,
+  ws: null,
+  playCtx: null, gain: null, analyser: null,
+  micCtx: null, micStream: null,
+  activeSources: [], nextPlayTime: 0,
+  queue: [], busy: false, current: null,
+  scene: null, userSpeaking: false,
+
+  // ---- lifecycle ----------------------------------------------------
+  async summon() {
+    const btn = document.getElementById("ractor-btn");
+    btn.disabled = true; btn.textContent = "🎭 Summoning…";
+    try {
+      // Playback chain: gain → analyser (drives the sigil) → speakers.
+      this.playCtx = new AudioContext({ sampleRate: VOICE_SAMPLE_RATE });
+      this.gain = this.playCtx.createGain();
+      this.analyser = this.playCtx.createAnalyser();
+      this.analyser.fftSize = 256;
+      this.gain.connect(this.analyser);
+      this.analyser.connect(this.playCtx.destination);
+
+      const tokenRes = await fetch("/api/token");
+      const tokenData = await tokenRes.json();
+      if (!tokenRes.ok) throw new Error(tokenData.error || "token fetch failed");
+      const key = tokenData.client_secret?.value || tokenData.value;
+      if (!key) throw new Error("no client_secret in token response");
+
+      this.ws = new WebSocket(`wss://api.openai.com/v1/realtime?model=${VOICE_MODEL}`,
+        ["realtime", `openai-insecure-api-key.${key}`]);
+      this.ws.addEventListener("open", () => this.onOpen());
+      this.ws.addEventListener("message", e => this.onMessage(e));
+      this.ws.addEventListener("close", () => this.teardown("The ractor's voice faded (connection closed)."));
+      this.ws.addEventListener("error", () => this.teardown("The ractor could not be reached."));
+    } catch (e) {
+      addMsg("error", "Ractor", esc(e.message), "", { silent: true });
+      this.teardown();
+    }
+  },
+
+  async onOpen() {
+    this.send("session.update", {
+      session: {
+        type: "realtime",
+        instructions: VOICE_INSTRUCTIONS,
+        tools: VOICE_TOOLS,
+        tool_choice: "auto",
+        audio: {
+          input: {
+            format: { type: "audio/pcm", rate: VOICE_SAMPLE_RATE },
+            transcription: { model: "gpt-4o-mini-transcribe" },
+            turn_detection: { type: "semantic_vad", eagerness: "medium", interrupt_response: true },
+          },
+          output: {
+            format: { type: "audio/pcm", rate: VOICE_SAMPLE_RATE },
+            voice: VOICE_NAME,
+          },
+        },
+      },
+    });
+    await this.startMic();
+    this.on = true;
+    const btn = document.getElementById("ractor-btn");
+    btn.disabled = false; btn.textContent = "🎭 Dismiss the Ractor"; btn.classList.add("live");
+    document.getElementById("sigil").style.display = "block";
+    this.orbLoop();
+    if (this.scene) this.pushScene();
+    this.enqueue("The book opens its mouth. Speak when you wish, Bridgekeeper — I am listening as well as telling.");
+  },
+
+  teardown(reason) {
+    const wasOn = this.on;
+    this.on = false;
+    try { this.ws?.close(); } catch {}
+    this.ws = null;
+    this.micStream?.getTracks().forEach(t => t.stop());
+    try { this.micCtx?.close(); } catch {}
+    try { this.playCtx?.close(); } catch {}
+    this.micStream = this.micCtx = this.playCtx = null;
+    this.activeSources = []; this.nextPlayTime = 0;
+    // Release anything the engine is waiting on, so the game keeps flowing.
+    this.queue.splice(0).forEach(q => q.done?.());
+    this.current?.done?.(); this.current = null; this.busy = false;
+    const btn = document.getElementById("ractor-btn");
+    btn.disabled = false; btn.textContent = "🎭 Summon the Ractor"; btn.classList.remove("live");
+    document.getElementById("sigil").style.display = "none";
+    if (wasOn && reason) addMsg("primer", "The Primer", esc(reason), "", { silent: true });
+  },
+
+  send(type, data = {}) {
+    if (this.ws?.readyState === WebSocket.OPEN) this.ws.send(JSON.stringify({ type, ...data }));
+  },
+
+  // ---- narration queue ------------------------------------------------
+  // One spoken performance at a time; response.done pumps the next.
+  enqueue(text) { if (this.connected()) { this.queue.push({ text }); this.pump(); } },
+  speakAndWait(text) {
+    if (!this.connected()) return Promise.resolve();
+    return new Promise(res => {
+      const item = { text, done: res };
+      // Safety valve: never let a lost response wedge the game.
+      item.timer = setTimeout(() => { item.done = null; res(); }, 60_000);
+      this.queue.push(item);
+      this.pump();
+    });
+  },
+  connected() { return this.on && this.ws?.readyState === WebSocket.OPEN; },
+  pump() {
+    if (this.busy || !this.queue.length || !this.connected()) return;
+    this.busy = true;
+    this.current = this.queue.shift();
+    this.send("response.create", {
+      response: { instructions: `NARRATION — perform this Primer line aloud verbatim:\n"${this.current.text}"` },
+    });
+  },
+  finishCurrent() {
+    if (this.current) {
+      clearTimeout(this.current.timer);
+      this.current.done?.();
+      this.current = null;
+    }
+    this.busy = false;
+    this.pump();
+  },
+
+  // ---- scene sync ------------------------------------------------------
+  setScene(scene) {
+    this.scene = scene;
+    if (scene && this.connected()) this.pushScene();
+  },
+  sceneJson() {
+    if (!this.scene) return { note: "No interactive prompt on screen right now — narration or transition." };
+    const { kind, prompt, options, hint } = this.scene;
+    return { kind, prompt, options, hint };
+  },
+  pushScene() {
+    // Context only — no response.create; the model uses it on the next turn.
+    this.send("conversation.item.create", {
+      item: { type: "message", role: "system",
+        content: [{ type: "input_text", text: "SCENE: " + JSON.stringify(this.sceneJson()) }] },
+    });
+  },
+
+  // ---- realtime events -------------------------------------------------
+  onMessage(event) {
+    const msg = JSON.parse(event.data);
+    switch (msg.type) {
+      case "response.output_audio.delta":
+        this.playDelta(msg.delta);
+        break;
+      case "response.done":
+        this.finishCurrent();
+        break;
+      case "response.function_call_arguments.done":
+        this.handleTool(msg);
+        break;
+      case "conversation.item.input_audio_transcription.completed":
+        if (msg.transcript?.trim())
+          addMsg("you", "@nick 🎙", esc(msg.transcript.trim()), "", { silent: true });
+        break;
+      case "input_audio_buffer.speech_started":
+        this.userSpeaking = true;
+        this.interrupt();
+        break;
+      case "input_audio_buffer.speech_stopped":
+        this.userSpeaking = false;
+        break;
+      case "error":
+        // Narration raced an in-flight response: requeue and retry on its done.
+        if (msg.error?.code === "conversation_already_has_active_response" && this.current) {
+          this.queue.unshift(this.current);
+          this.current = null; this.busy = false;
+          break;
+        }
+        if (msg.error?.code === "response_cancel_not_active") break;
+        console.error("Realtime error:", msg.error);
+        break;
+    }
+  },
+
+  // ---- tools: the ractor's hands on the game ---------------------------
+  async handleTool(msg) {
+    const args = JSON.parse(msg.arguments || "{}");
+    const reply = out => {
+      this.send("conversation.item.create",
+        { item: { type: "function_call_output", call_id: msg.call_id, output: JSON.stringify(out) } });
+      this.send("response.create", {});
+    };
+    try {
+      switch (msg.name) {
+        case "get_scene": return reply(this.sceneJson());
+        case "answer_choice":
+          if (this.scene?.choose) { this.scene.choose(args.index); return reply({ ok: true }); }
+          return reply({ error: "no choice puzzle on screen" });
+        case "answer_multi":
+          if (this.scene?.apply) { this.scene.apply(args.indices || []); return reply({ ok: true }); }
+          return reply({ error: "no multi-select puzzle on screen" });
+        case "type_command":
+          if (this.scene?.type) { this.scene.type(args.text || ""); return reply({ ok: true, typed: args.text }); }
+          return reply({ error: "no command input on screen" });
+        case "request_chapter":
+          if (this.scene?.write) { this.scene.write(args.topic || ""); return reply({ ok: true, status: "the scholar is writing — it takes a minute or two" }); }
+          return reply({ error: "not at a chapter gate" });
+        case "finish_game":
+          if (this.scene?.finish) { this.scene.finish(); return reply({ ok: true }); }
+          return reply({ error: "not at a chapter gate" });
+        case "consult_library": {
+          learner.questions.push(args.question);
+          const r = await fetch("/api/ask", {
+            method: "POST", headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ question: args.question, chapter: currentChapter, learner }),
+          });
+          const data = await r.json();
+          if (data.error) return reply({ error: data.error });
+          addMsg("primer", "The Primer", data.html, "", { silent: true });  // show the full text too
+          return reply({ answer: stripHtml(data.html).slice(0, 2400) });
+        }
+        default: return reply({ error: "unknown tool" });
+      }
+    } catch (e) {
+      reply({ error: e.message });
+    }
+  },
+
+  // ---- audio out --------------------------------------------------------
+  playDelta(delta) {
+    if (!delta || !this.playCtx) return;
+    const binary = atob(delta);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    const pcm16 = new Int16Array(bytes.buffer);
+    const float32 = new Float32Array(pcm16.length);
+    for (let i = 0; i < pcm16.length; i++) float32[i] = pcm16[i] / 0x8000;
+    const buf = this.playCtx.createBuffer(1, float32.length, VOICE_SAMPLE_RATE);
+    buf.copyToChannel(float32, 0);
+    const src = this.playCtx.createBufferSource();
+    src.buffer = buf;
+    src.connect(this.gain);
+    const t = Math.max(this.playCtx.currentTime, this.nextPlayTime);
+    src.start(t);
+    this.nextPlayTime = t + buf.duration;
+    this.activeSources.push(src);
+    if (this.activeSources.length > 64) this.activeSources.splice(0, 32);
+  },
+  interrupt() {  // barge-in: silence the book instantly; the server cancels the response
+    this.activeSources.forEach(s => { try { s.stop(); } catch {} });
+    this.activeSources = [];
+    this.nextPlayTime = 0;
+  },
+
+  // ---- audio in -----------------------------------------------------------
+  async startMic() {
+    this.micStream = await navigator.mediaDevices.getUserMedia({
+      audio: { channelCount: 1, sampleRate: VOICE_SAMPLE_RATE,
+               echoCancellation: true, noiseSuppression: true, autoGainControl: true },
+    });
+    this.micCtx = new AudioContext({ sampleRate: VOICE_SAMPLE_RATE });
+    await this.micCtx.audioWorklet.addModule("/mic-worklet.js");
+    const srcNode = this.micCtx.createMediaStreamSource(this.micStream);
+    const micNode = new AudioWorkletNode(this.micCtx, "mic-processor");
+    srcNode.connect(micNode);
+    micNode.port.onmessage = e => {
+      if (!this.connected()) return;
+      const bytes = new Uint8Array(e.data);
+      let bin = "";
+      for (let i = 0; i < bytes.length; i += 0x8000)
+        bin += String.fromCharCode.apply(null, bytes.subarray(i, i + 0x8000));
+      this.send("input_audio_buffer.append", { audio: btoa(bin) });
+    };
+  },
+
+  // ---- the sigil: an audio-reactive golden seal ----------------------------
+  orbLoop() {
+    const canvas = document.getElementById("sigil");
+    const ctx2d = canvas.getContext("2d");
+    const data = new Uint8Array(this.analyser.frequencyBinCount);
+    const draw = () => {
+      if (!this.on) return;
+      this.analyser.getByteFrequencyData(data);
+      let sum = 0;
+      for (let k = 0; k < data.length; k++) sum += data[k];
+      const level = sum / data.length / 255;                      // 0..1 speech energy
+      const breath = 0.5 + 0.5 * Math.sin(performance.now() / 900);
+      const r = 24 + breath * 4 + level * 28;
+      ctx2d.clearRect(0, 0, 120, 120);
+      const g = ctx2d.createRadialGradient(60, 60, 4, 60, 60, r);
+      g.addColorStop(0, "rgba(255, 226, 140, 0.95)");
+      g.addColorStop(0.6, "rgba(232, 184, 75, 0.55)");
+      g.addColorStop(1, "rgba(232, 184, 75, 0)");
+      ctx2d.fillStyle = g;
+      ctx2d.beginPath(); ctx2d.arc(60, 60, r, 0, 7); ctx2d.fill();
+      // Listening ring: green while the learner is speaking.
+      ctx2d.strokeStyle = this.userSpeaking ? "rgba(13,189,139,0.9)" : "rgba(232,184,75,0.35)";
+      ctx2d.lineWidth = 2;
+      ctx2d.beginPath(); ctx2d.arc(60, 60, 34 + breath * 3, 0, 7); ctx2d.stroke();
+      requestAnimationFrame(draw);
+    };
+    requestAnimationFrame(draw);
+  },
+};
+
+document.getElementById("ractor-btn").onclick = () =>
+  voice.on ? voice.teardown("The book falls quiet. Summon me again whenever you wish.") : voice.summon();
 
 /* ---- field notes ----------------------------------------------------- */
 const FIELD_NOTES = `
@@ -781,6 +1220,7 @@ fetch("/api/health").then(r => r.json()).then(d => {
     const light = document.getElementById("ractor-light");
     light.textContent = "● ractor live — the Primer can research & write new chapters";
     light.className = "live";
+    if (d.voice) document.getElementById("ractor-btn").style.display = "inline-block";
   }
 }).catch(() => {}).finally(run);
 </script>

--- a/primer/index.html
+++ b/primer/index.html
@@ -1,0 +1,788 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>The Bridgekeeper's Primer</title>
+<style>
+  :root {
+    --bg: #0f1117;
+    --panel: #181b24;
+    --panel2: #1f2330;
+    --text: #d8dce8;
+    --dim: #8b91a5;
+    --gold: #e8b84b;
+    --matrix: #0dbd8b;
+    --discord: #5865f2;
+    --telegram: #29a9eb;
+    --whatsapp: #25d366;
+    --signal: #3a76f0;
+    --error: #f25f5c;
+    --radius: 12px;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: "Avenir Next", "Segoe UI", system-ui, sans-serif;
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+  header {
+    padding: 14px 22px;
+    background: var(--panel);
+    border-bottom: 1px solid #2a2f3e;
+    display: flex;
+    align-items: baseline;
+    gap: 14px;
+    flex-wrap: wrap;
+  }
+  header h1 { font-size: 1.05rem; color: var(--gold); letter-spacing: 0.04em; }
+  header .subtitle { font-size: 0.78rem; color: var(--dim); font-style: italic; }
+  #badges { margin-left: auto; display: flex; gap: 6px; flex-wrap: wrap; }
+  .badge-chip {
+    font-size: 0.68rem;
+    padding: 3px 9px;
+    border-radius: 999px;
+    border: 1px solid var(--gold);
+    color: var(--gold);
+    opacity: 0;
+    transform: scale(0.6);
+    transition: all 0.5s cubic-bezier(0.2, 1.6, 0.4, 1);
+  }
+  .badge-chip.earned { opacity: 1; transform: scale(1); }
+
+  #room-bar {
+    padding: 8px 22px;
+    background: var(--panel2);
+    font-size: 0.78rem;
+    color: var(--dim);
+    border-bottom: 1px solid #2a2f3e;
+    display: flex;
+    align-items: center;
+  }
+  #room-bar b { color: var(--text); }
+  #ractor-light { margin-left: auto; font-size: 0.7rem; }
+  #ractor-light.live { color: var(--matrix); }
+  #ractor-light.off { color: var(--dim); }
+
+  #chat {
+    flex: 1;
+    overflow-y: auto;
+    padding: 20px 22px 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    scroll-behavior: smooth;
+  }
+  .chapter-rule {
+    text-align: center;
+    color: var(--gold);
+    font-size: 0.78rem;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    margin: 18px 0 8px;
+    opacity: 0.9;
+  }
+  .chapter-rule::before, .chapter-rule::after { content: " ─── "; color: #3a4054; }
+
+  .msg {
+    max-width: 720px;
+    padding: 9px 14px;
+    border-radius: var(--radius);
+    background: var(--panel);
+    border-left: 3px solid var(--dim);
+    animation: pop 0.25s ease-out;
+    line-height: 1.5;
+    font-size: 0.9rem;
+  }
+  @keyframes pop { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: none; } }
+  .msg .sender { font-weight: 600; font-size: 0.78rem; margin-bottom: 2px; display: flex; gap: 8px; align-items: baseline; }
+  .msg .tag { font-size: 0.62rem; padding: 1px 7px; border-radius: 999px; color: #fff; opacity: 0.85; }
+  .msg code { background: #0b0d12; padding: 1px 6px; border-radius: 5px; font-size: 0.82rem; color: #9fe8c8; }
+
+  .p-primer   { border-color: var(--gold); }     .p-primer .sender   { color: var(--gold); }
+  .p-matrix   { border-color: var(--matrix); }   .p-matrix .sender   { color: var(--matrix); }
+  .p-discord  { border-color: var(--discord); }  .p-discord .sender  { color: #8b97ff; }
+  .p-telegram { border-color: var(--telegram); } .p-telegram .sender { color: var(--telegram); }
+  .p-whatsapp { border-color: var(--whatsapp); } .p-whatsapp .sender { color: var(--whatsapp); }
+  .p-signal   { border-color: var(--signal); }   .p-signal .sender   { color: #7da4ff; }
+  .p-error    { border-color: var(--error); background: #241418; } .p-error .sender { color: var(--error); }
+  .p-you      { border-color: #c0c6da; align-self: flex-end; background: #232a3d; } .p-you .sender { color: #c0c6da; }
+
+  .t-primer   { background: #8a6a1d; }
+  .t-matrix   { background: #0a8f6a; }
+  .t-discord  { background: var(--discord); }
+  .t-telegram { background: #1d83b8; }
+  .t-whatsapp { background: #1a9c4b; }
+  .t-signal   { background: #2f5fc4; }
+  .t-error    { background: #a33; }
+  .t-you      { background: #4a5168; }
+
+  .thinking { font-style: italic; color: var(--dim); }
+  .thinking::after { content: "…"; animation: dots 1.4s steps(4) infinite; }
+  @keyframes dots { 0% { content: ""; } 25% { content: "."; } 50% { content: ".."; } 75% { content: "..."; } }
+
+  #controls {
+    padding: 14px 22px 18px;
+    background: var(--panel);
+    border-top: 1px solid #2a2f3e;
+    min-height: 86px;
+  }
+  .choices { display: flex; flex-direction: column; gap: 8px; max-width: 760px; }
+  .choices .prompt { font-size: 0.85rem; color: var(--gold); margin-bottom: 2px; }
+  button.opt, button.go {
+    text-align: left;
+    background: var(--panel2);
+    color: var(--text);
+    border: 1px solid #323950;
+    border-radius: 10px;
+    padding: 10px 14px;
+    font-size: 0.88rem;
+    cursor: pointer;
+    transition: border-color 0.15s, background 0.15s;
+    font-family: inherit;
+  }
+  button.opt:hover { border-color: var(--gold); background: #242a3c; }
+  button.opt.picked-wrong { border-color: var(--error); animation: shake 0.3s; }
+  button.opt.selected { border-color: var(--matrix); background: #1b2e2a; }
+  @keyframes shake { 25% { transform: translateX(-5px); } 75% { transform: translateX(5px); } }
+  button.go {
+    text-align: center;
+    border-color: var(--gold);
+    color: var(--gold);
+    font-weight: 600;
+    align-self: flex-start;
+    padding: 9px 26px;
+  }
+  button.go:hover { background: #2c2616; }
+  button:disabled { opacity: 0.5; cursor: default; }
+
+  .inputrow { display: flex; gap: 8px; max-width: 760px; align-items: center; }
+  .inputrow input, .inputrow textarea {
+    flex: 1;
+    background: #0b0d12;
+    border: 1px solid #323950;
+    color: #cfe8da;
+    font-family: "SF Mono", "Fira Code", Menlo, monospace;
+    font-size: 0.88rem;
+    padding: 11px 14px;
+    border-radius: 10px;
+    outline: none;
+  }
+  .inputrow input:focus { border-color: var(--matrix); }
+  .hintbtn { background: none; border: none; color: var(--dim); cursor: pointer; font-size: 0.78rem; text-decoration: underline dotted; font-family: inherit; }
+  .hintbtn:hover { color: var(--gold); }
+
+  /* Ask-the-Primer dock — present whenever the ractor is live */
+  #ask-dock {
+    display: none;
+    position: fixed;
+    right: 18px;
+    bottom: 104px;
+    z-index: 5;
+  }
+  #ask-toggle {
+    background: var(--panel2);
+    border: 1px solid var(--gold);
+    color: var(--gold);
+    border-radius: 999px;
+    padding: 9px 16px;
+    font-size: 0.8rem;
+    cursor: pointer;
+    font-family: inherit;
+    box-shadow: 0 4px 18px rgba(0,0,0,0.45);
+  }
+  #ask-toggle:hover { background: #2c2616; }
+  #ask-panel {
+    display: none;
+    position: absolute;
+    right: 0;
+    bottom: 46px;
+    width: min(420px, 90vw);
+    background: var(--panel);
+    border: 1px solid #3a4054;
+    border-radius: var(--radius);
+    padding: 14px;
+    box-shadow: 0 8px 30px rgba(0,0,0,0.55);
+  }
+  #ask-panel .label { font-size: 0.78rem; color: var(--gold); margin-bottom: 8px; }
+  #ask-panel textarea {
+    width: 100%;
+    height: 64px;
+    resize: vertical;
+    background: #0b0d12;
+    border: 1px solid #323950;
+    border-radius: 8px;
+    color: var(--text);
+    font-family: inherit;
+    font-size: 0.85rem;
+    padding: 9px 11px;
+    outline: none;
+  }
+  #ask-panel textarea:focus { border-color: var(--gold); }
+  #ask-panel .row { display: flex; justify-content: flex-end; margin-top: 8px; }
+
+  .fanout { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 6px; }
+  .fanout .dest {
+    font-size: 0.72rem;
+    padding: 4px 10px;
+    border-radius: 999px;
+    color: #fff;
+    opacity: 0;
+    transform: translateY(6px);
+    animation: pop 0.4s ease-out forwards;
+  }
+
+  #victory {
+    display: none;
+    position: fixed; inset: 0;
+    background: rgba(10, 12, 18, 0.92);
+    z-index: 10;
+    align-items: center; justify-content: center;
+    flex-direction: column; gap: 18px;
+    text-align: center; padding: 30px;
+  }
+  #victory h2 { color: var(--gold); font-size: 1.6rem; letter-spacing: 0.06em; }
+  #victory .scroll {
+    background: var(--panel);
+    border: 1px solid #3a4054;
+    border-radius: var(--radius);
+    padding: 22px 28px;
+    max-width: 640px;
+    max-height: 55vh;
+    overflow-y: auto;
+    text-align: left;
+    font-size: 0.85rem;
+    line-height: 1.7;
+  }
+  #victory .scroll h3 { color: var(--matrix); font-size: 0.9rem; margin: 12px 0 4px; }
+  #victory .scroll code { background: #0b0d12; padding: 1px 6px; border-radius: 5px; color: #9fe8c8; }
+</style>
+</head>
+<body>
+
+<header>
+  <h1>⛩ The Bridgekeeper's Primer</h1>
+  <span class="subtitle">A Young Imagineer's Illustrated Guide to the Superbridge</span>
+  <div id="badges"></div>
+</header>
+<div id="room-bar">
+  📍 <b id="room-name">#admins:imagineering.cc</b> <span id="room-desc"></span>
+  <span id="ractor-light" class="off">○ ractor offline — static lessons only</span>
+</div>
+<div id="chat"></div>
+<div id="controls"></div>
+
+<div id="ask-dock">
+  <div id="ask-panel">
+    <div class="label">🪶 Ask the Primer anything — it will search this repo and the web before answering.</div>
+    <textarea id="ask-text" placeholder="e.g. why can't the relay just edit the portal room's name?"></textarea>
+    <div class="row"><button class="go" id="ask-send">Ask</button></div>
+  </div>
+  <button id="ask-toggle">🪶 Ask the Primer</button>
+</div>
+
+<div id="victory">
+  <h2>🏅 Bridgekeeper</h2>
+  <div class="scroll" id="fieldnotes"></div>
+  <button class="go" onclick="location.reload()">Play again</button>
+</div>
+
+<script>
+"use strict";
+/* ============================================================
+   The Bridgekeeper's Primer — a chat-shaped teaching game about
+   Matrix bridges: plumbing vs portals, the megabridge wall, the
+   Telegram receiver-lock, the relay appservice, and loop prevention.
+
+   Two layers:
+   1. A scripted arc (Chapters I-VI) — every puzzle is a real gotcha
+      from the imagineering.cc superbridge's history.
+   2. A live "ractor" (server.mjs → headless Claude Code) that answers
+      free questions mid-game and WRITES NEW CHAPTERS after the arc,
+      adapted to the learner's mistakes — researching the repo and the
+      mautrix docs as it goes. Without the server the game still runs;
+      the adaptive layer simply stays dark.
+   ============================================================ */
+
+// ---- learner model: everything the ractor adapts to ----------------
+const learner = {
+  mistakes: [],   // {chapter, prompt, picked, why}
+  hints: 0,
+  questions: [],  // free-text questions asked mid-game
+  completed: [],  // chapter titles finished
+};
+let currentChapter = "Prologue";
+
+// ---- script-builder helpers ----------------------------------------
+let S = [];  // the script: a MUTABLE sequence of steps (generated chapters splice in)
+const chapter = (title) => S.push({ t: "chapter", title });
+const room    = (name, desc) => S.push({ t: "room", name, desc });
+const say     = (platform, sender, text, ms = 850) => S.push({ t: "msg", platform, sender, text, ms });
+const primer  = (text, ms = 1100) => say("primer", "The Primer", text, ms);
+const choice  = (prompt, options) => S.push({ t: "choice", prompt, options });
+const multi   = (prompt, options, applyLabel) => S.push({ t: "multi", prompt, options, applyLabel });
+const input   = (prompt, pattern, hint, placeholder) => S.push({ t: "input", prompt, pattern, hint, placeholder });
+const badge   = (name) => S.push({ t: "badge", name });
+const fanout  = () => S.push({ t: "fanout" });
+const gate    = () => S.push({ t: "gate" });    // offer ractor-written chapters
+const finale  = () => S.push({ t: "finale" });
+
+/* ================= CHAPTER 1 — THE HUB ========================= */
+chapter("Chapter I · The Hub");
+room("#admins:imagineering.cc", "— the homeserver admin room");
+primer("Welcome, Bridgekeeper. Five communities chatter in five walled gardens: <b>Discord</b>, <b>Telegram</b>, <b>WhatsApp</b>, <b>Signal</b>, and <b>Matrix</b> itself. Your task: one room to bind them.");
+primer("First, a question of <i>sovereignty</i>. Every bridged chat needs a Matrix room to mirror it. The question that decides everything else is: <b>who owns that room?</b>");
+choice("Where should the hub room come from?", [
+  { label: "Let the WhatsApp bridge create it for me — it does that automatically.",
+    ok: false,
+    fb: "That room would be a <b>portal</b> — created, owned, and state-enforced by the bridge. You'd be a guest in its house, and it won't let four other bridges move in on your terms." },
+  { label: "Create the room myself, then invite the bridges in as guests.",
+    ok: true,
+    fb: "Exactly. A room <i>you</i> own, with bridges attached to it, is called <b>plumbing</b>. You set the name, the rules, the guest list. Remember this word — the whole game turns on it." },
+]);
+say("matrix", "@nick", "<code>./superbridge.sh create-room</code>");
+say("matrix", "System", "Room created: <code>!hub:imagineering.cc</code> · alias <code>#superbridge</code>");
+room("#superbridge:imagineering.cc", "— your hub room");
+primer("Your hall stands. Two house rules before the guests arrive.");
+choice("Should the hub room be end-to-end encrypted?", [
+  { label: "Yes — encrypt everything, always.",
+    ok: false,
+    fb: "Noble instinct, wrong room. The bridge bots must <i>read</i> every message to relay it. E2EE would hand them ciphertext they can't decrypt — the hub would fall silent. Bridged rooms stay unencrypted; the bridges themselves are the trust boundary." },
+  { label: "No — leave it unencrypted so the bridges can read and relay.",
+    ok: true,
+    fb: "Right. The room is unencrypted by design (and <code>m.federate: false</code> keeps it local to your homeserver). The bridges are middlemen; middlemen must see the letters they carry." },
+]);
+choice("The four bridge bots arrive at the door. What power level do you grant them?", [
+  { label: "PL 0 — they're just bots.",
+    ok: false,
+    fb: "Too low. Bridges write <b>state events</b> into the room to record their plumbing, and <code>state_default</code> is 50. At PL 0 they can talk but never attach anything." },
+  { label: "PL 50 — enough to write state, not enough to rule.",
+    ok: true,
+    fb: "The traditional grant. PL 50 clears <code>state_default</code> so bots can manage plumbing and ghost users, while you alone hold 100." },
+  { label: "PL 100 — full admin, keep it simple.",
+    ok: false,
+    fb: "Now four robots can demote <i>you</i>. Least privilege, Bridgekeeper: 50 is all the power a bridge needs." },
+]);
+say("matrix", "System", "Invited: <code>@discordbot</code> <code>@telegrambot</code> <code>@whatsappbot</code> <code>@signalbot</code> — all at PL 50");
+badge("Room Sovereign");
+
+/* ================= CHAPTER 2 — PLUMBING DISCORD ================= */
+chapter("Chapter II · Plumbing, First Class");
+primer("The Discord bridge is the elder of the four — a standalone Go bridge from before the great rewrite. It still speaks fluent <b>plumbing</b>: it will attach a Discord channel to a room you already own.");
+primer("In Discord, you enable <i>Developer Mode</i>, right-click the channel, and copy its ID: <code>9001</code>. Now speak the plumbing command <b>here in the hub</b> — the bridge bot is listening. (Format: <code>!discord bridge &lt;channel-id&gt;</code>)");
+input("Type the command to plumb Discord channel 9001 into this room:",
+  /^!discord\s+bridge\s+9001$/i,
+  "It starts with <code>!discord bridge</code> — then the channel ID you copied: 9001.",
+  "!discord bridge 9001");
+say("discord", "Discord bridge", "Channel <b>#imagineering</b> bridged to this room. ⚓");
+say("discord", "Maxwell 🦊", "hello from Discord! can everyone see this?");
+primer("Messages flow in! But watch what happens when a Matrix user replies…");
+say("matrix", "@nick", "loud and clear!");
+say("error", "Discord side", "In Discord, that arrived as <b>matrix-bridge-bot</b>: “nick: loud and clear!” — a robot reading mail aloud. The humans deserve faces.");
+primer("The fix: <b>relay webhooks</b>. One more command teaches the bridge to post into Discord with each sender's own name and avatar.");
+input("Type the command to enable webhook relay:",
+  /^!discord\s+set-relay$/i,
+  "Same bot, command is <code>set-relay</code>.",
+  "!discord set-relay");
+say("discord", "Discord bridge", "Relay webhook configured. Matrix users now appear in Discord with their own names and avatars. ✨");
+badge("Plumber, First Class");
+
+/* ============ CHAPTER 3 — THE TELEGRAM TRAP ===================== */
+chapter("Chapter III · The Telegram Trap");
+primer("Telegram next. The command looks the same — <code>!tg bridge</code> — but beware: this bridge was quietly <b>rewritten</b> onto the new shared framework, <i>bridgev2</i>, the one they call the <b>megabridge</b>.");
+primer("Megabridge portals are <b>split</b>: every bridged chat is <i>owned by the login it was bridged through</i> — the <b>receiver</b>. And only the receiver's login may serve as the relay for users who aren't logged in. Choose your receiver as carefully as a king chooses an heir.");
+choice("How do you bridge the Telegram group?", [
+  { label: "Bridge it now with my personal Telegram login — I'll sort out a bot later.",
+    ok: false,
+    fb: "🪤 <b>The trap closes.</b> The portal is now received by <i>you</i>, personally. When you later try <code>!tg set-relay</code> with a bot, the bridge refuses — only the receiver's login can relay. Worse: <code>!tg unset-relay</code> panics with a nil-pointer crash (a real mautrix v0.27.0 bug — though the panic does clear the relay as a side effect, which is its own kind of dark comedy). Back up and choose again." },
+  { label: "Log in a dedicated bot account first, then bridge with the bot as receiver.",
+    ok: true,
+    fb: "Wisdom. <code>login bot</code> with a BotFather token, make the bot an <b>admin in the Telegram group</b>, and bridge through it — the bot becomes the receiver, and relay rights follow the bot forever after." },
+]);
+say("telegram", "Telegram bridge", "Logged in as bot <b>ImagineeringRelayBot</b> (tgid <code>7654321</code>)");
+primer("Now plumb it. In bridgev2 the command names the receiver: <code>!tg bridge &lt;bot_tgid&gt; &lt;chat_id&gt;</code>. The bot's tgid is <code>7654321</code>; the supergroup's chat ID is <code>-1001234</code> (mind the minus — supergroups are negative numbers, like debts).");
+input("Type the bridgev2 plumbing command:",
+  /^!tg\s+bridge\s+7654321\s+-1001234$/i,
+  "<code>!tg bridge 7654321 -1001234</code> — bot tgid first, then the negative chat ID.",
+  "!tg bridge 7654321 -1001234");
+say("telegram", "Telegram bridge", "Group <b>Imagineering</b> bridged · receiver: ImagineeringRelayBot ⚓");
+input("One more — enable the relay so non-logged-in Matrix users reach Telegram:",
+  /^!tg\s+set-relay$/i,
+  "Mirror of the Discord step: <code>!tg set-relay</code>.",
+  "!tg set-relay");
+say("telegram", "Telegram bridge", "Relay enabled through the receiver's login. ✨");
+badge("Receiver of Portals");
+
+/* ============ CHAPTER 4 — THE MEGABRIDGE WALL =================== */
+chapter("Chapter IV · The Megabridge Wall");
+primer("Two to go. Confident now, you turn to WhatsApp and speak the old plumbing words…");
+say("matrix", "@nick", "<code>!wa open 6147xxxx@g.us</code>");
+say("error", "WhatsApp bridge", "Unknown command in this room. Creating portal room <b>“Imagineering (WA)”</b> elsewhere…");
+room("Imagineering (WA)", "— a portal room the bridge created and owns");
+say("whatsapp", "WhatsApp bridge", "This is the portal for your WhatsApp group. I own this room. I sync its name, avatar, and members from WhatsApp. It will mirror the group — and nothing else.");
+primer("There it is: <b>the megabridge wall</b>. WhatsApp and Signal run purely on the bridgev2 megabridge, and its shared core supports <i>only</i> the portal model. Plumbing wasn't broken — it was <b>designed out</b>. A bridge-owned room is a room the core can keep perfectly in sync, because nobody else may rearrange the furniture.");
+choice("The hub is here; the portal is there. What do you do?", [
+  { label: "Force it — edit the bridge's database so the portal points at the hub room.",
+    ok: false,
+    fb: "The core will fight you. It <i>enforces</i> that portal state mirrors the remote chat — your hub's name, members, and power levels would be 'corrected' out from under you. You cannot out-stubborn a sync loop." },
+  { label: "Abandon WhatsApp and Signal. Three platforms is plenty.",
+    ok: false,
+    fb: "Bridgekeeper. We do not leave communities behind." },
+  { label: "Accept the portal — and build a relay appservice that copies portal ↔ hub, speaking as each sender through puppet users.",
+    ok: true,
+    fb: "The artificer's answer — and the real one. If the megabridge insists on owning its rooms, let it. Your appservice sits in the portal, hears every message, and re-speaks it in the hub through a <b>puppet</b> (<code>@_relay_whatsapp_ab12:…</code>) wearing the sender's name and avatar. Plumbing, rebuilt one layer up." },
+]);
+primer("An appservice needs configuration: which rooms are spokes, and which is the hub.");
+choice("Which PORTAL_ROOMS value is well-formed?", [
+  { label: "PORTAL_ROOMS=whatsapp,signal",
+    ok: false,
+    fb: "Labels alone — but the appservice needs actual room IDs to join and listen." },
+  { label: "PORTAL_ROOMS=!wa-room:imagineering.cc=WhatsApp,!sig-room:imagineering.cc=Signal",
+    ok: true,
+    fb: "Correct: <code>!room_id:domain=Label</code>, comma-separated. Each portal gets a human label; <code>HUB_ROOM_ID</code> names the hall they all feed." },
+  { label: "PORTAL_ROOMS=#superbridge:imagineering.cc",
+    ok: false,
+    fb: "That's the hub's alias — the one room that must <i>not</i> be in the portal list, or you've built a snake eating its tail." },
+]);
+room("#admins:imagineering.cc", "— back in the admin room");
+primer("Last rite: the homeserver must be told this appservice exists and may puppet the <code>@_relay_*</code> namespace. On Continuwuity there is no config file to edit and no restart — you <i>register it live, in chat</i>, here in #admins, then paste the registration.yaml.");
+input("Type the admin command to register the appservice:",
+  /^!admin\s+appservices\s+register$/i,
+  "<code>!admin appservices register</code> — then you'd paste the YAML.",
+  "!admin appservices register");
+say("matrix", "Continuwuity", "Appservice <b>relay-bot</b> registered · namespace <code>@_relay_*</code> claimed · effective immediately, no restart.");
+badge("Appservice Artificer");
+
+/* ================ CHAPTER 5 — THE LOOP ========================== */
+chapter("Chapter V · The Loop");
+room("#superbridge:imagineering.cc", "— the hub, suddenly very noisy");
+primer("The relay awakens — and the room begins to <b>boil</b>.");
+say("whatsapp", "Alice", "hi everyone!", 500);
+say("matrix", "_relay_whatsapp_ab12 (puppet)", "hi everyone!", 420);
+say("whatsapp", "Alice", "hi everyone!", 340);
+say("matrix", "_relay_whatsapp_ab12 (puppet)", "hi everyone!", 280);
+say("error", "System", "⚠ Message volume rising… the relay is relaying its own relays. Each copy spawns a copy. This is the <b>echo storm</b> — the dragon every bridge-builder must slay exactly once.", 1200);
+multi("Which senders must the relay refuse to relay? (Select all that apply, then seal the wards.)", [
+  { label: "Its own puppet users — anyone matching @_relay_*", ok: true,
+    why: "Layer 1: never echo yourself. The puppets' messages ARE the relay's output." },
+  { label: "The bridge bots and their ghosts in portal rooms", ok: true,
+    why: "Layer 2: the megabridge already delivered those into the portal — relaying them back creates the cross-bridge loop." },
+  { label: "Messages already carrying a “Name: ” attribution prefix", ok: true,
+    why: "Layer 3: an attribution prefix means some other relay already spoke this message once. Re-relaying re-attributes — “Alice: Alice: Alice: hi”." },
+  { label: "All messages from Telegram users", ok: false,
+    why: "That's not loop prevention, that's censorship — Telegram folk are exactly who we're bridging FOR." },
+], "Seal the wards");
+say("matrix", "relay-bot", "Loop prevention armed: three layers. The storm dies. The room is quiet — the good kind of quiet. 🕯");
+badge("Loopbreaker");
+
+/* ================ CHAPTER 6 — FAN-OUT =========================== */
+chapter("Chapter VI · One Room, Five Worlds");
+primer("Everything stands: a hub you own, two bridges plumbed in directly, two megabridge portals relayed through puppets, and wards against the storm. One thing remains, Bridgekeeper: <b>say something</b>.");
+input("Send any message to the hub:",
+  /^.{1,200}$/,
+  "Anything at all. It's your room.",
+  "say hello to five worlds…");
+fanout();
+primer("It lands everywhere — and on each platform it wears <i>your</i> face, not a robot's. That is the whole craft: <b>plumbing where the bridges allow it, puppetry where they don't, and wards against your own echo.</b>");
+badge("Bridgekeeper");
+gate();    // the ractor offers to write Chapter VII+, adapted to this learner
+finale();
+
+/* ============================================================
+   ENGINE
+   ============================================================ */
+const chatEl = document.getElementById("chat");
+const controlsEl = document.getElementById("controls");
+const badgesEl = document.getElementById("badges");
+const ALL_BADGES = ["Room Sovereign", "Plumber, First Class", "Receiver of Portals", "Appservice Artificer", "Loopbreaker", "Bridgekeeper"];
+ALL_BADGES.forEach(addBadgeChip);
+function addBadgeChip(b) {
+  const chip = document.createElement("span");
+  chip.className = "badge-chip";
+  chip.id = "badge-" + b.replace(/\W+/g, "-");
+  chip.textContent = "🏅 " + b;
+  badgesEl.appendChild(chip);
+  return chip;
+}
+
+let i = 0;          // step pointer
+let lastSaid = "";  // captured fan-out message
+let ractor = false; // is the adaptive server alive?
+
+function el(html) { const d = document.createElement("div"); d.innerHTML = html; return d.firstElementChild; }
+function scroll() { chatEl.scrollTop = chatEl.scrollHeight; }
+function esc(s) { return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;"); }
+
+function addMsg(platform, sender, text, extraClass = "") {
+  const tag = { primer: "PRIMER", matrix: "MATRIX", discord: "DISCORD", telegram: "TELEGRAM",
+                whatsapp: "WHATSAPP", signal: "SIGNAL", error: "!", you: "YOU" }[platform] || platform;
+  const node = el(
+    `<div class="msg p-${platform} ${extraClass}">
+       <div class="sender">${sender} <span class="tag t-${platform}">${tag}</span></div>
+       <div class="body">${text}</div>
+     </div>`);
+  chatEl.appendChild(node);
+  scroll();
+  return node;
+}
+
+function next() { i++; run(); }
+
+/** Splice ractor-generated steps into the live script just after the pointer. */
+function injectSteps(rawSteps) {
+  const cleaned = rawSteps.map(s => {
+    if (s.t === "input" && typeof s.pattern === "string") {
+      try { s.pattern = new RegExp(s.pattern, "i"); }
+      catch { s.pattern = /^.{1,200}$/; }  // forgiving fallback if the regex is malformed
+    }
+    return s;
+  }).filter(s => ["chapter", "room", "msg", "choice", "multi", "input", "badge"].includes(s.t));
+  S.splice(i + 1, 0, ...cleaned);
+}
+
+function recordMistake(prompt, picked, why) {
+  learner.mistakes.push({ chapter: currentChapter, prompt, picked, why: why.replace(/<[^>]+>/g, "") });
+}
+
+function run() {
+  if (i >= S.length) return;
+  const s = S[i];
+  controlsEl.innerHTML = "";
+
+  switch (s.t) {
+    case "chapter":
+      currentChapter = s.title;
+      chatEl.appendChild(el(`<div class="chapter-rule">${s.title}</div>`));
+      scroll();
+      setTimeout(next, 700);
+      break;
+
+    case "room":
+      document.getElementById("room-name").textContent = s.name;
+      document.getElementById("room-desc").textContent = " " + (s.desc || "");
+      setTimeout(next, 300);
+      break;
+
+    case "msg":
+      addMsg(s.platform, s.sender, s.text);
+      setTimeout(next, s.ms || 850);
+      break;
+
+    case "choice": {
+      const box = el(`<div class="choices"><div class="prompt">⚖ ${s.prompt}</div></div>`);
+      s.options.forEach(o => {
+        const b = el(`<button class="opt">${esc(o.label)}</button>`);
+        b.onclick = () => {
+          if (o.ok) {
+            addMsg("primer", "The Primer", "✅ " + o.fb);
+            next();
+          } else {
+            b.classList.add("picked-wrong");
+            b.disabled = true;
+            recordMistake(s.prompt, o.label, o.fb);
+            addMsg("primer", "The Primer", "❌ " + o.fb);
+          }
+        };
+        box.appendChild(b);
+      });
+      controlsEl.appendChild(box);
+      break;
+    }
+
+    case "multi": {
+      const box = el(`<div class="choices"><div class="prompt">⚖ ${s.prompt}</div></div>`);
+      const state = new Map();
+      s.options.forEach(o => {
+        const b = el(`<button class="opt">${esc(o.label)}</button>`);
+        state.set(o, false);
+        b.onclick = () => { state.set(o, !state.get(o)); b.classList.toggle("selected"); };
+        box.appendChild(b);
+      });
+      const go = el(`<button class="go">${s.applyLabel || "Apply"}</button>`);
+      go.onclick = () => {
+        const wrongPick = s.options.find(o => state.get(o) && !o.ok);
+        const missing = s.options.find(o => !state.get(o) && o.ok);
+        if (wrongPick) { recordMistake(s.prompt, wrongPick.label, wrongPick.why); addMsg("primer", "The Primer", "❌ Not that one — " + wrongPick.why); return; }
+        if (missing)   { addMsg("primer", "The Primer", "🤔 The wards are incomplete. Something that should be ignored… isn't yet."); return; }
+        s.options.filter(o => o.ok).forEach(o => addMsg("primer", "The Primer", "🛡 " + o.why));
+        next();
+      };
+      box.appendChild(go);
+      controlsEl.appendChild(box);
+      break;
+    }
+
+    case "input": {
+      const box = el(`<div class="choices"><div class="prompt">⌨ ${s.prompt}</div></div>`);
+      const row = el(`<div class="inputrow"></div>`);
+      const inp = el(`<input type="text" placeholder="${esc(s.placeholder || "")}" autocomplete="off" spellcheck="false">`);
+      const hint = el(`<button class="hintbtn">hint?</button>`);
+      hint.onclick = () => { learner.hints++; addMsg("primer", "The Primer", "💡 " + s.hint); };
+      const submit = () => {
+        const v = inp.value.trim().replace(/\s+/g, " ");
+        if (s.pattern.test(v)) {
+          addMsg("you", "@nick", esc(v));
+          lastSaid = v;
+          next();
+        } else {
+          inp.style.borderColor = "var(--error)";
+          setTimeout(() => inp.style.borderColor = "", 400);
+          addMsg("primer", "The Primer", "That incantation fizzles. Try again — or ask for a <i>hint</i>.");
+        }
+      };
+      inp.addEventListener("keydown", e => { if (e.key === "Enter") submit(); });
+      const go = el(`<button class="go">Send</button>`);
+      go.onclick = submit;
+      row.appendChild(inp); row.appendChild(go); row.appendChild(hint);
+      box.appendChild(row);
+      controlsEl.appendChild(box);
+      inp.focus();
+      break;
+    }
+
+    case "badge": {
+      let chip = document.getElementById("badge-" + s.name.replace(/\W+/g, "-"));
+      if (!chip) chip = addBadgeChip(s.name);   // ractor-written chapters mint new badges
+      chip.classList.add("earned");
+      learner.completed.push(currentChapter);
+      addMsg("primer", "The Primer", `🏅 Badge earned: <b>${s.name}</b>`);
+      setTimeout(next, 900);
+      break;
+    }
+
+    case "fanout": {
+      const dests = [
+        ["discord", "Discord · as “nick” via webhook"],
+        ["telegram", "Telegram · via the bot receiver's relay"],
+        ["whatsapp", "WhatsApp · via puppet @_relay_*"],
+        ["signal", "Signal · via puppet @_relay_*"],
+      ];
+      const wrap = el(`<div class="msg p-you"><div class="sender">@nick <span class="tag t-matrix">HUB</span></div>
+        <div>${esc(lastSaid)}</div><div class="fanout"></div></div>`);
+      chatEl.appendChild(wrap);
+      const fan = wrap.querySelector(".fanout");
+      dests.forEach(([p, label], n) => {
+        fan.appendChild(el(`<span class="dest t-${p}" style="animation-delay:${0.4 + n * 0.45}s">→ ${label}</span>`));
+      });
+      scroll();
+      setTimeout(next, 2600);
+      break;
+    }
+
+    case "gate": {
+      if (!ractor) { next(); break; }   // no server: skip straight to the field notes
+      primerGate();
+      break;
+    }
+
+    case "finale": {
+      document.getElementById("fieldnotes").innerHTML = FIELD_NOTES;
+      document.getElementById("victory").style.display = "flex";
+      break;
+    }
+  }
+}
+
+/* ---- the ractor gate: ask Claude to write the next chapter ---------- */
+function primerGate() {
+  addMsg("primer", "The Primer",
+    "The scripted lessons end here — but <i>I</i> do not. I can write your next chapter myself: " +
+    "I will reread the relay's source, search the mautrix docs, and weave a lesson around " +
+    (learner.mistakes.length ? "the places where you stumbled." : "whatever calls to you next."));
+  const box = el(`<div class="choices">
+    <div class="prompt">📜 Shall the Primer write Chapter ${["VII","VIII","IX","X","XI","XII"][Math.min(learner.completed.length - 6, 5)] || "VII"}?</div>
+  </div>`);
+  const row = el(`<div class="inputrow"></div>`);
+  const inp = el(`<input type="text" placeholder="optional: a topic — e.g. double puppeting, reply threading, media relay…">`);
+  const go = el(`<button class="go">Write it</button>`);
+  const skip = el(`<button class="hintbtn">finish instead → field notes</button>`);
+  go.onclick = async () => {
+    const topic = inp.value.trim();
+    go.disabled = true; inp.disabled = true;
+    const thinking = addMsg("primer", "The Primer",
+      `<span class="thinking">Researching${topic ? " “" + esc(topic) + "”" : ""} — reading relay/appservice/, consulting docs.mau.fi</span>`);
+    try {
+      const r = await fetch("/api/chapter", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ learner, completed: learner.completed, topic }),
+      });
+      const data = await r.json();
+      if (data.error) throw new Error(data.error);
+      thinking.querySelector(".body").innerHTML = "📜 The new chapter is written. Turn the page…";
+      injectSteps([...data.steps, { t: "gate" }]);   // re-offer after each generated chapter
+      next();
+    } catch (e) {
+      thinking.querySelector(".body").innerHTML =
+        "⚠ The ink ran dry (" + esc(e.message) + "). You may try again, or finish.";
+      go.disabled = false; inp.disabled = false;
+    }
+  };
+  skip.onclick = next;
+  row.appendChild(inp); row.appendChild(go);
+  box.appendChild(row); box.appendChild(skip);
+  controlsEl.appendChild(box);
+}
+
+/* ---- Ask-the-Primer dock (live whenever the server is up) ----------- */
+const dock = document.getElementById("ask-dock");
+const askPanel = document.getElementById("ask-panel");
+document.getElementById("ask-toggle").onclick = () =>
+  askPanel.style.display = askPanel.style.display === "block" ? "none" : "block";
+document.getElementById("ask-send").onclick = async () => {
+  const ta = document.getElementById("ask-text");
+  const q = ta.value.trim();
+  if (!q) return;
+  ta.value = "";
+  askPanel.style.display = "none";
+  learner.questions.push(q);
+  addMsg("you", "@nick", esc(q));
+  const thinking = addMsg("primer", "The Primer", `<span class="thinking">Searching the repo and the wider web</span>`);
+  try {
+    const r = await fetch("/api/ask", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ question: q, chapter: currentChapter, learner }),
+    });
+    const data = await r.json();
+    if (data.error) throw new Error(data.error);
+    thinking.querySelector(".body").innerHTML = data.html;
+  } catch (e) {
+    thinking.querySelector(".body").innerHTML = "⚠ I could not reach my library: " + esc(e.message);
+  }
+  scroll();
+};
+
+/* ---- field notes ----------------------------------------------------- */
+const FIELD_NOTES = `
+  <h3>Field Notes — what you now know</h3>
+  <p><b>Plumbing</b>: attaching a remote chat to a Matrix room <i>you</i> created and own. The bridge is a guest.</p>
+  <p><b>Portal</b>: a room the bridge creates and owns, one per remote chat, state-synced by force.</p>
+  <p><b>Megabridge (bridgev2)</b>: mautrix's shared Go core. Portal-only by design — plumbing was designed out, not broken. WhatsApp, Signal, and (newly) Telegram run on it.</p>
+  <p><b>Split portals / receiver</b>: in bridgev2, a bridged chat belongs to the login it was bridged through, and only the receiver's login can relay. Log in the bot <i>first</i>.</p>
+  <p><b>Relay appservice</b>: the adapter when plumbing is forbidden — sits in portal rooms, re-speaks each message into the hub through per-sender puppets (<code>@_relay_*</code>).</p>
+  <p><b>Loop prevention, three layers</b>: ignore your own puppets · ignore bridge bots/ghosts · ignore already-attributed messages.</p>
+  <h3>The real incantations</h3>
+  <p><code>./superbridge.sh create-room</code> · <code>!discord bridge &lt;id&gt;</code> · <code>!discord set-relay</code><br>
+  <code>login bot</code> → <code>!tg bridge &lt;bot_tgid&gt; &lt;chat_id&gt;</code> → <code>!tg set-relay</code><br>
+  <code>!admin appservices register</code> (live, in #admins, no restart)<br>
+  <code>PORTAL_ROOMS=!room:domain=Label,…</code> + <code>HUB_ROOM_ID</code></p>
+  <p style="color:var(--dim); margin-top:10px"><i>Built from the true history of the imagineering.cc superbridge — including the trap, the wall, and the storm.</i></p>`;
+
+/* ---- boot: detect the ractor, then begin ----------------------------- */
+fetch("/api/health").then(r => r.json()).then(d => {
+  if (d.ok) {
+    ractor = true;
+    dock.style.display = "block";
+    const light = document.getElementById("ractor-light");
+    light.textContent = "● ractor live — the Primer can research & write new chapters";
+    light.className = "live";
+  }
+}).catch(() => {}).finally(run);
+</script>
+</body>
+</html>

--- a/primer/index.html
+++ b/primer/index.html
@@ -290,6 +290,7 @@
 <header>
   <h1>⛩ The Bridgekeeper's Primer</h1>
   <span class="subtitle">A Young Imagineer's Illustrated Guide to the Superbridge</span>
+  <a href="/land" style="font-size:0.74rem; color:#b9a5f5; text-decoration:none; border:1px solid #6a4fc4; border-radius:999px; padding:5px 14px;">🌌 Mautrix Galaxy</a>
   <button id="ractor-btn">🎭 Summon the Ractor</button>
   <div id="badges"></div>
 </header>

--- a/primer/land.html
+++ b/primer/land.html
@@ -1,0 +1,684 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Mautrix Galaxy — the Continuwuity Observatory</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { background: #06070d; overflow: hidden; font-family: "Avenir Next", "Segoe UI", system-ui, sans-serif; }
+  canvas { display: block; }
+
+  #hud { position: fixed; inset: 0; pointer-events: none; color: #e8ecf5; }
+  #room-label {
+    position: absolute; top: 16px; left: 18px;
+    font-size: 0.95rem; font-weight: 600; color: #e8b84b;
+    text-shadow: 0 2px 8px rgba(0,0,0,0.8);
+  }
+  #room-sub { position: absolute; top: 38px; left: 18px; font-size: 0.72rem; color: #aab2c8; text-shadow: 0 2px 8px rgba(0,0,0,0.8); }
+  #storm-counter {
+    display: none;
+    position: absolute; top: 16px; right: 18px;
+    font-size: 0.9rem; font-weight: 700; color: #f25f5c;
+    text-shadow: 0 2px 8px rgba(0,0,0,0.9);
+  }
+  #crosshair {
+    position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);
+    width: 6px; height: 6px; border-radius: 50%;
+    background: rgba(232, 184, 75, 0.9);
+    box-shadow: 0 0 8px rgba(0,0,0,0.6);
+  }
+  #prompt {
+    position: absolute; bottom: 88px; left: 50%; transform: translateX(-50%);
+    font-size: 0.88rem; color: #ffe89c; text-shadow: 0 2px 8px rgba(0,0,0,0.9);
+    background: rgba(8, 9, 16, 0.65); padding: 7px 16px; border-radius: 999px;
+    border: 1px solid rgba(232, 184, 75, 0.5);
+    display: none;
+  }
+  #lore {
+    position: absolute; bottom: 20px; left: 50%; transform: translateX(-50%);
+    max-width: 680px; width: 90vw;
+    font-size: 0.85rem; line-height: 1.55;
+    background: rgba(8, 9, 16, 0.84); padding: 12px 18px; border-radius: 12px;
+    border-left: 3px solid #e8b84b;
+    opacity: 0; transition: opacity 0.4s;
+  }
+  #lore b { color: #e8b84b; } #lore code { color: #9fe8c8; background: #0b0d12; padding: 0 5px; border-radius: 4px; }
+
+  #intro {
+    position: fixed; inset: 0; z-index: 10;
+    background: rgba(6, 7, 13, 0.93);
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+    color: #d8dce8; text-align: center; gap: 16px; cursor: pointer;
+  }
+  #intro h1 { color: #e8b84b; letter-spacing: 0.05em; font-size: 1.7rem; }
+  #intro .sub { font-style: italic; color: #8b91a5; }
+  #intro .controls { font-size: 0.85rem; line-height: 2; }
+  #intro .controls b { color: #0dbd8b; }
+  #intro .start { margin-top: 10px; color: #e8b84b; border: 1px solid #e8b84b; border-radius: 999px; padding: 10px 28px; }
+</style>
+</head>
+<body>
+
+<div id="intro">
+  <h1>🌌 MAUTRIX GALAXY</h1>
+  <div class="sub">The Continuwuity Observatory — where the superbridge orbits</div>
+  <div class="controls">
+    <b>WASD</b> walk (all the way around a world) &nbsp;·&nbsp; <b>mouse</b> look &nbsp;·&nbsp; <b>space</b> jump &nbsp;·&nbsp; <b>E</b> interact<br>
+    Worlds are rooms. Pipes are plumbing. Wormholes are megabridge portals.<br>
+    The ghosts you'll see are <code style="color:#9fe8c8">@_relay_*</code> puppets, carrying mail through subspace.
+  </div>
+  <div class="start">Click to drift in</div>
+</div>
+
+<div id="hud">
+  <div id="room-label"></div>
+  <div id="room-sub"></div>
+  <div id="storm-counter">⚠ echoes: <span id="echo-n">0</span></div>
+  <div id="crosshair"></div>
+  <div id="prompt"></div>
+  <div id="lore"></div>
+</div>
+
+<script type="importmap">
+{ "imports": { "three": "https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js" } }
+</script>
+<script type="module">
+import * as THREE from "three";
+
+/* ============================================================
+   MAUTRIX GALAXY — a spherical-gravity teaching cosmos
+   (Mario Galaxy energy: planetoids, launch stars, wormholes).
+
+   The metaphor map (architecture → game):
+     homeserver        → the galaxy / observatory itself
+     Matrix rooms      → planetoids; membership = which world you stand on
+                          (you cannot WALK to another room — you are
+                           launched, piped, or admitted)
+     plumbing          → green pipes arcing between worlds YOU own,
+                          with launch stars to ride alongside your mail
+     megabridge portal → WORMHOLES — the only way into bridge-owned
+                          worlds; no pipe, no launch star, their terms
+     messages          → envelopes, colour-tagged by platform
+     relay puppets     → ghosts that dive INTO a planet and surface on
+                          the hub (appservices travel subspace, beneath
+                          the rooms)
+     loop prevention   → three ward-stones that end the Echo Storm
+   ============================================================ */
+
+const v = (x, y, z) => new THREE.Vector3(x, y, z);
+
+// ---------- palette ----------
+const C = {
+  gold: 0xe8b84b, matrix: 0x0dbd8b, discord: 0x5865f2, telegram: 0x29a9eb,
+  whatsapp: 0x25d366, signal: 0x3a76f0, pipe: 0x1a9c4b, ghost: 0xe8ecf5,
+  cursed: 0xf25f5c, rock: 0x2e3344, rock2: 0x394056,
+};
+
+// ---------- renderer / scene ----------
+const scene = new THREE.Scene();
+scene.background = new THREE.Color(0x06070d);
+const camera = new THREE.PerspectiveCamera(74, innerWidth / innerHeight, 0.1, 600);
+const renderer = new THREE.WebGLRenderer({ antialias: true });
+renderer.setSize(innerWidth, innerHeight);
+renderer.setPixelRatio(Math.min(devicePixelRatio, 2));
+document.body.appendChild(renderer.domElement);
+addEventListener("resize", () => {
+  camera.aspect = innerWidth / innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(innerWidth, innerHeight);
+});
+
+scene.add(new THREE.HemisphereLight(0xcfd8ff, 0x10121c, 0.55));
+const sun = new THREE.DirectionalLight(0xfff2d0, 1.4);
+sun.position.set(60, 90, 40);
+scene.add(sun);
+function lamp(pos, color = 0xffe0a0, intensity = 30, dist = 30) {
+  const l = new THREE.PointLight(color, intensity, dist, 1.8);
+  l.position.copy(pos);
+  scene.add(l);
+}
+
+// ---------- starfield + a distant federation galaxy ----------
+{
+  const N = 2200, pts = new Float32Array(N * 3);
+  for (let i = 0; i < N; i++) {
+    const d = 180 + Math.random() * 240;
+    const th = Math.random() * Math.PI * 2, ph = Math.acos(2 * Math.random() - 1);
+    pts[i * 3] = d * Math.sin(ph) * Math.cos(th);
+    pts[i * 3 + 1] = d * Math.cos(ph);
+    pts[i * 3 + 2] = d * Math.sin(ph) * Math.sin(th);
+  }
+  const g = new THREE.BufferGeometry();
+  g.setAttribute("position", new THREE.BufferAttribute(pts, 3));
+  scene.add(new THREE.Points(g, new THREE.PointsMaterial({ color: 0xbfc8e8, size: 0.7, sizeAttenuation: false })));
+}
+{ // spiral galaxy far off — federation lives out there
+  const N = 900, pts = new Float32Array(N * 3);
+  for (let i = 0; i < N; i++) {
+    const arm = (i % 3) * (Math.PI * 2 / 3);
+    const t = (i / N) * 5;
+    const r = 2 + t * 7 + Math.random() * 2.5;
+    const a = arm + t * 1.7 + Math.random() * 0.25;
+    pts[i * 3] = -150 + Math.cos(a) * r;
+    pts[i * 3 + 1] = 85 + (Math.random() - 0.5) * 3;
+    pts[i * 3 + 2] = -200 + Math.sin(a) * r;
+  }
+  const g = new THREE.BufferGeometry();
+  g.setAttribute("position", new THREE.BufferAttribute(pts, 3));
+  scene.add(new THREE.Points(g, new THREE.PointsMaterial({ color: 0xb9a5f5, size: 1.1, sizeAttenuation: false, transparent: true, opacity: 0.8 })));
+}
+
+// ---------- planetoids (rooms) ----------
+const PLANETS = {
+  admin:    { c: v(0, 3, 36),     r: 5,   color: 0x3a4054, name: "Admin Planetoid", sub: "#admins · the registrar's desk" },
+  hub:      { c: v(0, 0, 0),      r: 11,  color: 0x35406a, name: "The Hub World", sub: "#superbridge — one world, five galaxies" },
+  discord:  { c: v(-44, 10, -12), r: 7,   color: 0x2c3163, name: "Discord Planetoid", sub: "plumbed · standalone Go bridge" },
+  telegram: { c: v(44, -8, -12),  r: 7,   color: 0x1d3a4d, name: "Telegram Planetoid", sub: "plumbed · bridgev2 — mind the receiver" },
+  whatsapp: { c: v(-38, 34, -86), r: 6.5, color: 0x1d4030, name: "WhatsApp Portal World", sub: "bridge-owned · wormhole-only · doorless" },
+  signal:   { c: v(38, -30, -86), r: 6.5, color: 0x1d2a4d, name: "Signal Portal World", sub: "bridge-owned · wormhole-only · doorless" },
+};
+const mat = c => new THREE.MeshLambertMaterial({ color: c });
+for (const p of Object.values(PLANETS)) {
+  const m = new THREE.Mesh(new THREE.SphereGeometry(p.r, 36, 24), mat(p.color));
+  m.position.copy(p.c);
+  scene.add(m);
+  // a few craters/rocks for texture
+  for (let i = 0; i < 7; i++) {
+    const d = v(Math.random() - 0.5, Math.random() - 0.5, Math.random() - 0.5).normalize();
+    const rock = new THREE.Mesh(new THREE.DodecahedronGeometry(0.3 + Math.random() * 0.5), mat(C.rock2));
+    rock.position.copy(p.c).addScaledVector(d, p.r - 0.1);
+    scene.add(rock);
+  }
+}
+const surfacePoint = (p, dir, h = 0) => p.c.clone().addScaledVector(dir.clone().normalize(), p.r + h);
+
+/** Stand `obj` on a planet surface: position at dir, +Y aligned to the normal. */
+function placeOnPlanet(obj, p, dir, h = 0) {
+  const n = dir.clone().normalize();
+  obj.position.copy(surfacePoint(p, n, h));
+  obj.quaternion.setFromUnitVectors(v(0, 1, 0), n);
+  scene.add(obj);
+  return obj;
+}
+function boxOnPlanet(w, hgt, d, color, p, dir, lift = 0) {
+  const m = new THREE.Mesh(new THREE.BoxGeometry(w, hgt, d), mat(color));
+  return placeOnPlanet(m, p, dir, hgt / 2 + lift);
+}
+
+// ---------- signage (billboards — always face the player) ----------
+const billboards = [];
+function sign(p, dir, h, lines, fg = "#e8b84b", bg = "#161927") {
+  const cv = document.createElement("canvas");
+  cv.width = 512; cv.height = 256;
+  const g = cv.getContext("2d");
+  g.fillStyle = bg; g.fillRect(0, 0, 512, 256);
+  g.strokeStyle = fg; g.lineWidth = 8; g.strokeRect(8, 8, 496, 240);
+  g.fillStyle = fg; g.textAlign = "center";
+  lines.forEach((ln, n) => {
+    g.font = n === 0 ? "bold 42px Avenir Next, sans-serif" : "26px Avenir Next, sans-serif";
+    g.fillText(ln, 256, 92 + n * 52);
+  });
+  const m = new THREE.Mesh(new THREE.PlaneGeometry(3.4, 1.7),
+    new THREE.MeshBasicMaterial({ map: new THREE.CanvasTexture(cv), transparent: false }));
+  m.position.copy(surfacePoint(p, dir, h));
+  scene.add(m);
+  billboards.push(m);
+  return m;
+}
+
+// ---------- furniture ----------
+// Admin planetoid: the registrar's desk (player spawns facing it)
+boxOnPlanet(2.4, 0.9, 1.1, 0x4a3b22, PLANETS.admin, v(0, 0.35, -1));
+sign(PLANETS.admin, v(0, 0.8, -1), 3.2, ["CONTINUWUITY OBSERVATORY", "#admins desk", "server name is permanent"]);
+
+// Hub world: the mail table at its north pole, where everything lands
+const HUB_UP = v(0, 1, 0);
+boxOnPlanet(6, 0.85, 2, 0x4a3b22, PLANETS.hub, HUB_UP);
+sign(PLANETS.hub, v(0.45, 1, 0.28), 3.4, ["THE HUB WORLD", "#superbridge", "one world, five galaxies"]);
+const hubTableTop = () => surfacePoint(PLANETS.hub, v((Math.random() - 0.5) * 0.18, 1, (Math.random() - 0.5) * 0.12), 1.15);
+
+sign(PLANETS.discord, v(0, 1, 0), 3, ["DISCORD PLANETOID", "plumbed: !discord bridge 9001"], "#8b97ff");
+sign(PLANETS.telegram, v(0, 1, 0), 3, ["TELEGRAM PLANETOID", "!tg bridge <bot_tgid> <chat_id>"], "#6fcaf2");
+sign(PLANETS.whatsapp, v(0, 1, 0.4), 3, ["WHATSAPP PORTAL WORLD", "the megabridge owns this world"], "#7fe8a8", "#10241a");
+sign(PLANETS.signal, v(0, 1, 0.4), 3, ["SIGNAL PORTAL WORLD", "the megabridge owns this world"], "#9ab8ff", "#131c30");
+
+// Portal-world mail tables (where local envelopes appear for ghosts)
+boxOnPlanet(2.4, 0.85, 1.3, 0x4a3b22, PLANETS.whatsapp, v(0.3, 1, -0.2));
+boxOnPlanet(2.4, 0.85, 1.3, 0x4a3b22, PLANETS.signal, v(0.3, 1, -0.2));
+
+lamp(surfacePoint(PLANETS.hub, HUB_UP, 5));
+lamp(surfacePoint(PLANETS.admin, v(0, 1, 0), 4), 0xffe0a0, 16, 18);
+lamp(surfacePoint(PLANETS.whatsapp, v(0, 1, 0), 4), 0x7fe8a8, 16, 18);
+lamp(surfacePoint(PLANETS.signal, v(0, 1, 0), 4), 0x9ab8ff, 16, 18);
+
+// ---------- plumbing: pipes arcing through space (hub ↔ discord/telegram) ----------
+function pipeBetween(pa, da, pb, db, bulge = 10) {
+  const a = surfacePoint(pa, da, 0.2), b = surfacePoint(pb, db, 0.2);
+  const mid = a.clone().add(b).multiplyScalar(0.5);
+  const out = mid.clone().sub(pa.c.clone().add(pb.c).multiplyScalar(0.5)).normalize();
+  mid.addScaledVector(out, bulge);
+  const curve = new THREE.QuadraticBezierCurve3(a, mid, b);
+  const tube = new THREE.Mesh(new THREE.TubeGeometry(curve, 40, 0.32, 10),
+    new THREE.MeshLambertMaterial({ color: C.pipe, emissive: C.pipe, emissiveIntensity: 0.12, transparent: true, opacity: 0.92 }));
+  scene.add(tube);
+  // pipe mouths
+  for (const [p, d] of [[pa, da], [pb, db]]) {
+    const rim = new THREE.Mesh(new THREE.TorusGeometry(0.5, 0.14, 10, 20), mat(C.pipe));
+    placeOnPlanet(rim, p, d, 0.4);
+    rim.rotateX(Math.PI / 2);
+  }
+  return curve;
+}
+const dirHubToDiscord = PLANETS.discord.c.clone().sub(PLANETS.hub.c).normalize();
+const dirHubToTelegram = PLANETS.telegram.c.clone().sub(PLANETS.hub.c).normalize();
+const DISCORD_PIPE = pipeBetween(PLANETS.hub, dirHubToDiscord, PLANETS.discord, dirHubToDiscord.clone().negate(), 9);
+const TELEGRAM_PIPE = pipeBetween(PLANETS.hub, dirHubToTelegram, PLANETS.telegram, dirHubToTelegram.clone().negate(), 9);
+
+// set-relay lever beside the Discord pipe mouth on the hub
+const leverDir = dirHubToDiscord.clone().add(v(0, 0.45, 0)).normalize();
+boxOnPlanet(0.5, 1.0, 0.5, 0x4a3b22, PLANETS.hub, leverDir);
+const leverStick = boxOnPlanet(0.12, 0.9, 0.12, 0xaab2c8, PLANETS.hub, leverDir, 0.8);
+leverStick.rotateZ(0.6);
+let relayOn = false;
+
+// ---------- launch stars (ride alongside your plumbed mail) ----------
+const launchMeshes = [];
+function launchStar(p, dir, target, targetDir, label) {
+  const star = new THREE.Mesh(new THREE.OctahedronGeometry(0.55),
+    new THREE.MeshLambertMaterial({ color: C.gold, emissive: C.gold, emissiveIntensity: 0.7 }));
+  placeOnPlanet(star, p, dir, 1.3);
+  launchMeshes.push(star);
+  interactables.push({
+    posFn: () => surfacePoint(p, dir, 1.3), r: 2.6, label,
+    act: () => beginFlight(p, dir, target, targetDir),
+  });
+}
+
+// ---------- wormholes (megabridge portals — their terms, no pipes) ----------
+const wormholes = [];
+function wormhole(pos, color, label, act) {
+  const grp = new THREE.Group();
+  const ring1 = new THREE.Mesh(new THREE.TorusGeometry(1.6, 0.12, 12, 40),
+    new THREE.MeshLambertMaterial({ color, emissive: color, emissiveIntensity: 0.9 }));
+  const ring2 = ring1.clone(); ring2.scale.setScalar(0.72);
+  const disc = new THREE.Mesh(new THREE.CircleGeometry(1.45, 36),
+    new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.22, side: THREE.DoubleSide }));
+  grp.add(ring1, ring2, disc);
+  grp.position.copy(pos);
+  scene.add(grp);
+  wormholes.push(grp);
+  billboards.push(grp);   // swirl always faces you
+  interactables.push({ posFn: () => pos, r: 2.8, label, act });
+  return grp;
+}
+
+// ---------- envelopes ----------
+const envelopes = [];
+function makeEnvelope(color) {
+  const g = new THREE.Group();
+  const body = new THREE.Mesh(new THREE.BoxGeometry(0.46, 0.1, 0.3), mat(0xf2f4fa));
+  const stripe = new THREE.Mesh(new THREE.BoxGeometry(0.48, 0.045, 0.32),
+    new THREE.MeshLambertMaterial({ color, emissive: color, emissiveIntensity: 0.45 }));
+  stripe.position.y = 0.06;
+  g.add(body, stripe);
+  scene.add(g);
+  return g;
+}
+function postEnvelope(color, path, speed = 7) {
+  envelopes.push({ m: makeEnvelope(color), path, t: 0, seg: 0, speed });
+}
+/** Mail rides a pipe INTO the hub: follow the curve wing→hub, then hop to the table.
+    (Pipe curves are built hub→wing, so we walk them reversed.) */
+function pipeDelivery(curve, color) {
+  const pts = curve.getPoints(36).reverse();
+  pts.push(hubTableTop());
+  postEnvelope(color, pts);
+}
+
+// ---------- ghosts (@_relay_* puppets, via subspace) ----------
+const ghosts = [];
+function makeGhost() {
+  const g = new THREE.Group();
+  const body = new THREE.Mesh(new THREE.SphereGeometry(0.42, 18, 14),
+    new THREE.MeshLambertMaterial({ color: C.ghost, transparent: true, opacity: 0.5, emissive: 0x8890b0, emissiveIntensity: 0.3 }));
+  body.scale.y = 1.25; g.add(body);
+  [[-0.14, 0.12, 0.36], [0.14, 0.12, 0.36]].forEach(p => {
+    const e = new THREE.Mesh(new THREE.SphereGeometry(0.06, 8, 8), new THREE.MeshBasicMaterial({ color: 0x1a1d28 }));
+    e.position.set(...p); g.add(e);
+  });
+  scene.add(g);
+  return g;
+}
+/** Rise on the portal world, collect an envelope, dive INTO the planet
+    (subspace!), surface on the hub, deliver, depart. */
+function ghostFerry(fromPlanet, color, hubDir) {
+  const tableDir = v(0.3, 1, -0.2).normalize();
+  const from = surfacePoint(fromPlanet, tableDir, 1.2);
+  const inside = surfacePoint(fromPlanet, tableDir, -2.5);
+  const hubInside = surfacePoint(PLANETS.hub, hubDir, -2.5);
+  const hubOut = surfacePoint(PLANETS.hub, hubDir, 1.2);
+  const g = makeGhost();
+  const env = makeEnvelope(color); env.visible = false;
+  ghosts.push({ g, env, color, phase: 0, t: 0,
+    path: [inside, from, from.clone(), inside.clone(), hubInside, hubOut, hubTableTop(), hubInside.clone()] });
+}
+const GHOST_DIR_WA = v(-0.7, 0.7, 0.2).normalize();
+const GHOST_DIR_SG = v(0.7, 0.7, 0.2).normalize();
+
+// ---------- traffic ----------
+setInterval(() => pipeDelivery(DISCORD_PIPE, relayOn ? C.discord : 0x8b91a5), 4600);
+setInterval(() => pipeDelivery(TELEGRAM_PIPE, C.telegram), 6200);
+setInterval(() => postEnvelope(relayOn ? C.matrix : 0x8b91a5, [hubTableTop(), ...DISCORD_PIPE.getPoints(36)]), 7900);
+setInterval(() => ghostFerry(PLANETS.whatsapp, C.whatsapp, GHOST_DIR_WA), 7200);
+setInterval(() => ghostFerry(PLANETS.signal, C.signal, GHOST_DIR_SG), 9800);
+
+// ---------- echo storm ----------
+let storm = false;
+const echoes = [];
+let lastDup = 0;
+const cursed = boxOnPlanet(0.5, 0.12, 0.34, C.cursed, PLANETS.hub, v(0.22, 1, 0.1), 1.0);
+cursed.material.emissive = new THREE.Color(C.cursed);
+const WARD_DEFS = [
+  { dir: v(-0.45, 1, 0.15), label: "Ward I — ignore @_relay_* puppets" },
+  { dir: v(0.45, 1, 0.15),  label: "Ward II — ignore bridge bots & ghosts" },
+  { dir: v(0, 1, -0.5),     label: "Ward III — ignore “Name:” attributed mail" },
+];
+const wards = WARD_DEFS.map(d => {
+  const m = boxOnPlanet(0.6, 1.6, 0.6, 0x6a4fc4, PLANETS.hub, d.dir.clone().normalize());
+  m.material.emissive = new THREE.Color(0x6a4fc4);
+  m.material.emissiveIntensity = 0;
+  m.visible = false;
+  return { ...d, mesh: m, lit: false };
+});
+function startStorm() {
+  if (storm) return;
+  storm = true;
+  cursed.visible = false;
+  document.getElementById("storm-counter").style.display = "block";
+  wards.forEach(w => { w.mesh.visible = true; w.lit = false; w.mesh.material.emissiveIntensity = 0; });
+  spawnEcho(surfacePoint(PLANETS.hub, HUB_UP, 2));
+  lore("⚠ <b>THE ECHO STORM.</b> The relay heard its own voice across the void and answered it. Every echo spawns an echo. " +
+       "Three ward-stones have risen around the mail table — light <b>all three layers of loop prevention</b> to end it.");
+}
+function spawnEcho(pos) {
+  const m = makeEnvelope(C.cursed);
+  m.position.copy(pos);
+  echoes.push({ m, vel: v((Math.random() - 0.5) * 6, (Math.random() - 0.5) * 6, (Math.random() - 0.5) * 6) });
+}
+function endStorm() {
+  storm = false;
+  echoes.forEach(e => scene.remove(e.m));
+  echoes.length = 0;
+  document.getElementById("storm-counter").style.display = "none";
+  setTimeout(() => wards.forEach(w => w.mesh.visible = false), 4000);
+  lore("🕯 <b>The storm dies.</b> Three layers, one law: a bridge must know its own voice — its puppets, its peers, " +
+       "and mail already spoken once — and refuse to repeat it. In the real relay this is <code>loop_prevention.py</code>: " +
+       "pure functions, three checks, and the silence stays the good kind.");
+}
+
+// ---------- lore HUD ----------
+const lore = (html, ms = 10000) => {
+  const L = document.getElementById("lore");
+  L.innerHTML = html;
+  L.style.opacity = 1;
+  clearTimeout(lore._t);
+  lore._t = setTimeout(() => L.style.opacity = 0, ms);
+};
+
+// ---------- interactables ----------
+const interactables = [];
+interactables.push(
+  { posFn: () => surfacePoint(PLANETS.admin, v(0, 0.35, -1), 1), r: 2.6, label: "read the registrar's desk", act: () =>
+      lore("🌌 <b>This observatory is the homeserver</b> — Continuwuity, one Rust process, RocksDB humming in the core. " +
+           "Every planetoid you can see is a Matrix room, and <b>standing on one is membership</b>. At this desk you'd speak " +
+           "<code>!admin appservices register</code> — the observatory licenses new ghosts in chat. No restart. No re-launch.") },
+  { posFn: () => surfacePoint(PLANETS.hub, HUB_UP, 1.2), r: 3, label: "inspect the mail table", when: () => !storm || true, act: () =>
+      lore("📬 <b>The Hub World.</b> All mail in the galaxy lands on this table. Pipes carry Discord and Telegram envelopes " +
+           "(<b>plumbing</b> — connections YOU laid, between worlds you own); ghosts surface with WhatsApp and Signal mail " +
+           "(<b>the relay appservice</b> — because wormhole-worlds accept no pipes). One world, five galaxies.") },
+  { posFn: () => surfacePoint(PLANETS.hub, dirHubToDiscord, 1), r: 2.6, label: "read the Discord pipe mouth", act: () =>
+      lore("🟢 <b>A pipe is plumbing.</b> <code>!discord bridge 9001</code> laid this line between a world you own and a channel " +
+           "out in Discord space. The elder Go bridge still speaks pipe; the megabridge generation refuses — that's why two of " +
+           "these worlds have no pipes at all.") },
+  { posFn: () => surfacePoint(PLANETS.telegram, v(0, 1, 0), 1), r: 3, label: "read the Telegram plaque", act: () =>
+      lore("🟦 <b>Telegram's pipe survived the bridgev2 rewrite</b> — with a new law: every pipe has a <b>receiver</b>, the login " +
+           "it was laid through, and only the receiver may relay. Lay it bot-first — <code>!tg bridge &lt;bot_tgid&gt; &lt;chat_id&gt;</code> — " +
+           "or the pipe is yours personally, forever, and <code>set-relay</code> will refuse you.") },
+  { posFn: () => surfacePoint(PLANETS.hub, leverDir, 1), r: 2.2, label: "pull the set-relay lever", act: () => {
+      relayOn = !relayOn;
+      leverStick.rotation.z += relayOn ? -1.2 : 1.2;
+      lore(relayOn
+        ? "✨ <b>set-relay ON.</b> Watch the Discord pipe: envelopes now arrive wearing their sender's colours — webhook relay gives every Matrix voice a Discord face."
+        : "🤖 <b>set-relay OFF.</b> Grey envelopes again: everything arrives as <i>matrix-bridge-bot reading mail aloud</i>."); } },
+  { posFn: () => cursed.position, r: 1.8, label: "touch the cursed envelope", when: () => !storm && cursed.visible, act: startStorm },
+);
+wards.forEach(w => interactables.push({
+  posFn: () => w.mesh.position, r: 2, label: `light ${w.label}`,
+  when: () => storm && !w.lit,
+  act: () => {
+    w.lit = true;
+    w.mesh.material.emissiveIntensity = 0.9;
+    const left = wards.filter(x => !x.lit).length;
+    if (!left) endStorm();
+    else lore(`🛡 <b>${w.label}</b> lit. ${left} ward${left > 1 ? "s" : ""} remain.`);
+  },
+}));
+
+// Launch stars: admin ↔ hub, hub ↔ discord, hub ↔ telegram (plumbed worlds only!)
+launchStar(PLANETS.admin, v(0, 0.6, 1), PLANETS.hub, v(0, 0.7, 1), "launch to the Hub World");
+launchStar(PLANETS.hub, v(0, 0.7, 1), PLANETS.admin, v(0, 0.6, 1), "launch to the Admin Planetoid");
+launchStar(PLANETS.hub, dirHubToDiscord.clone().add(v(0, -0.5, 0)).normalize(), PLANETS.discord, dirHubToDiscord.clone().negate(), "ride the plumbing to Discord");
+launchStar(PLANETS.discord, dirHubToDiscord.clone().negate().add(v(0, 0.5, 0)).normalize(), PLANETS.hub, dirHubToDiscord, "ride the plumbing back to the Hub");
+launchStar(PLANETS.hub, dirHubToTelegram.clone().add(v(0, -0.5, 0)).normalize(), PLANETS.telegram, dirHubToTelegram.clone().negate(), "ride the plumbing to Telegram");
+launchStar(PLANETS.telegram, dirHubToTelegram.clone().negate().add(v(0, 0.5, 0)).normalize(), PLANETS.hub, dirHubToTelegram, "ride the plumbing back to the Hub");
+
+// Wormholes: the ONLY route to portal worlds. Floating off the hub, on the bridge's terms.
+wormhole(surfacePoint(PLANETS.hub, v(-0.8, 0.5, -0.6).normalize(), 4.5), C.whatsapp, "enter the WhatsApp wormhole", () => {
+  arriveAt(PLANETS.whatsapp, v(0, 1, 1).normalize());
+  lore("🕳 <b>You are inside a portal world.</b> The megabridge spun this planet itself and OWNS it — name, terrain, guest list, " +
+       "all state-synced from the WhatsApp group. Notice: <b>no pipes, no launch stars</b>. You arrived by wormhole, on the " +
+       "bridge's terms. That is why the hub needed ghosts.");
+});
+wormhole(surfacePoint(PLANETS.hub, v(0.8, 0.5, -0.6).normalize(), 4.5), C.signal, "enter the Signal wormhole", () => {
+  arriveAt(PLANETS.signal, v(0, 1, 1).normalize());
+  lore("🕳 <b>The Signal portal world.</b> Same megabridge, same law: portal-only, bridge-owned, pipeless. Watch the mail table — " +
+       "when an envelope appears, a ghost will rise, collect it, and dive <i>into the planet</i>. Appservices travel subspace, " +
+       "beneath the rooms.");
+});
+wormhole(surfacePoint(PLANETS.whatsapp, v(0, 0.4, -1).normalize(), 4), C.whatsapp, "wormhole back to the Hub World", () => arriveAt(PLANETS.hub, HUB_UP));
+wormhole(surfacePoint(PLANETS.signal, v(0, 0.4, -1).normalize(), 4), C.signal, "wormhole back to the Hub World", () => arriveAt(PLANETS.hub, HUB_UP));
+
+// ---------- player: spherical gravity ----------
+const player = {
+  planet: PLANETS.admin,
+  pos: surfacePoint(PLANETS.admin, v(0, 0.2, 1), 1.7),
+  forward: v(0, 0, -1),
+  pitch: 0, vy: 0, grounded: true,
+  flight: null,   // {curve, t, dur, to, toDir}
+};
+function arriveAt(planet, dir) {
+  player.planet = planet;
+  player.pos = surfacePoint(planet, dir, 1.7);
+  player.vy = 0;
+  player.flight = null;
+}
+function beginFlight(fromPlanet, fromDir, toPlanet, toDir) {
+  const a = player.pos.clone();
+  const b = surfacePoint(toPlanet, toDir, 1.7);
+  const mid = a.clone().add(b).multiplyScalar(0.5);
+  const lift = mid.clone().sub(fromPlanet.c.clone().add(toPlanet.c).multiplyScalar(0.5)).normalize();
+  mid.addScaledVector(lift, 16);
+  player.flight = { curve: new THREE.QuadraticBezierCurve3(a, mid, b), t: 0, dur: 2.4, to: toPlanet, toDir };
+}
+
+const keys = {};
+addEventListener("keydown", e => {
+  keys[e.code] = true;
+  if (e.code === "KeyE") tryInteract();
+  if (e.code === "Space" && player.grounded && !player.flight) { player.vy = 5.4; player.grounded = false; }
+});
+addEventListener("keyup", e => keys[e.code] = false);
+
+const intro = document.getElementById("intro");
+intro.addEventListener("click", () => renderer.domElement.requestPointerLock());
+document.addEventListener("pointerlockchange", () => {
+  intro.style.display = document.pointerLockElement ? "none" : "flex";
+});
+let mouseDX = 0, mouseDY = 0;
+addEventListener("mousemove", e => {
+  if (!document.pointerLockElement) return;
+  mouseDX += e.movementX; mouseDY += e.movementY;
+});
+
+function updatePlayer(dt) {
+  if (player.flight) {   // riding a launch star
+    const f = player.flight;
+    f.t = Math.min(1, f.t + dt / f.dur);
+    player.pos.copy(f.curve.getPoint(f.t));
+    const gravC = f.t < 0.5 ? player.planet.c : f.to.c;
+    const up = player.pos.clone().sub(gravC).normalize();
+    const tan = f.curve.getTangent(f.t);
+    camera.up.lerp(up, 0.12).normalize();
+    camera.position.copy(player.pos);
+    camera.lookAt(player.pos.clone().add(tan));
+    if (f.t >= 1) {
+      const land = f.to;
+      player.planet = land;
+      const n = player.pos.clone().sub(land.c).normalize();
+      player.forward = tan.clone().addScaledVector(n, -tan.dot(n)).normalize();
+      player.vy = 0; player.flight = null;
+    }
+    return;
+  }
+
+  const P = player.planet;
+  let up = player.pos.clone().sub(P.c).normalize();
+
+  // mouse look: yaw spins `forward` around the local up; pitch is separate
+  if (mouseDX || mouseDY) {
+    player.forward.applyAxisAngle(up, -mouseDX * 0.0022);
+    player.pitch = Math.max(-1.35, Math.min(1.35, player.pitch - mouseDY * 0.0022));
+    mouseDX = mouseDY = 0;
+  }
+  // keep forward tangent to the sphere as we wander around it
+  player.forward.addScaledVector(up, -player.forward.dot(up)).normalize();
+  const right = player.forward.clone().cross(up); // forward×up = right (looking along forward)
+  const dir = v(0, 0, 0);
+  if (keys.KeyW) dir.add(player.forward);
+  if (keys.KeyS) dir.sub(player.forward);
+  if (keys.KeyD) dir.add(right);
+  if (keys.KeyA) dir.sub(right);
+  if (dir.lengthSq()) player.pos.addScaledVector(dir.normalize(), 5.6 * dt);
+
+  // radial gravity: fall toward the planet's heart
+  player.vy -= 13 * dt;
+  let h = player.pos.distanceTo(P.c) + player.vy * dt;
+  const minH = P.r + 1.7;
+  if (h <= minH) { h = minH; player.vy = 0; player.grounded = true; }
+  up = player.pos.clone().sub(P.c).normalize();
+  player.pos.copy(P.c).addScaledVector(up, h);
+
+  camera.position.copy(player.pos);
+  camera.up.copy(up);
+  camera.lookAt(player.pos.clone()
+    .addScaledVector(player.forward, Math.cos(player.pitch))
+    .addScaledVector(up, Math.sin(player.pitch)));
+}
+
+function nearestInteractable() {
+  for (const it of interactables) {
+    if (it.when && !it.when()) continue;
+    if (player.pos.distanceToSquared(it.posFn()) < it.r * it.r) return it;
+  }
+  return null;
+}
+function tryInteract() { nearestInteractable()?.act(); }
+
+// ---------- main loop ----------
+const promptEl = document.getElementById("prompt");
+const clock = new THREE.Clock();
+function tick() {
+  requestAnimationFrame(tick);
+  const dt = Math.min(clock.getDelta(), 0.05);
+
+  if (document.pointerLockElement || player.flight) updatePlayer(dt);
+  else { camera.position.copy(player.pos); }
+
+  // envelopes along waypoint paths
+  for (let n = envelopes.length - 1; n >= 0; n--) {
+    const e = envelopes[n];
+    const a = e.path[e.seg], b = e.path[e.seg + 1];
+    if (!b) { scene.remove(e.m); envelopes.splice(n, 1); continue; }
+    const L = a.distanceTo(b) || 0.001;
+    e.t += (e.speed * dt) / L;
+    if (e.t >= 1) { e.t = 0; e.seg++; } else e.m.position.lerpVectors(a, b, e.t);
+    e.m.rotation.y += dt * 2;
+  }
+
+  // ghosts through subspace
+  for (let n = ghosts.length - 1; n >= 0; n--) {
+    const gh = ghosts[n];
+    const a = gh.path[gh.phase], b = gh.path[gh.phase + 1];
+    if (!b) { scene.remove(gh.g); scene.remove(gh.env); ghosts.splice(n, 1); continue; }
+    const L = a.distanceTo(b) || 0.001;
+    gh.t += (3.2 * dt) / L;
+    if (gh.t >= 1) {
+      gh.t = 0; gh.phase++;
+      if (gh.phase === 2) gh.env.visible = true;
+      if (gh.phase === 7) {
+        gh.env.visible = false;
+        const drop = makeEnvelope(gh.color);
+        drop.position.copy(gh.g.position);
+        envelopes.push({ m: drop, path: [drop.position.clone(), hubTableTop()], t: 0, seg: 0, speed: 2.5 });
+      }
+    } else {
+      gh.g.position.lerpVectors(a, b, gh.t);
+      gh.env.position.copy(gh.g.position).add(v(0, -0.15, 0.3));
+    }
+  }
+
+  // echo storm: bounce inside a shell around the hub world
+  if (storm) {
+    for (const e of echoes) {
+      e.m.position.addScaledVector(e.vel, dt);
+      const rel = e.m.position.clone().sub(PLANETS.hub.c);
+      const d = rel.length(), nrm = rel.normalize();
+      if (d < PLANETS.hub.r + 0.6 || d > PLANETS.hub.r + 6) {
+        e.vel.addScaledVector(nrm, -2 * e.vel.dot(nrm));
+        e.m.position.copy(PLANETS.hub.c).addScaledVector(nrm, Math.max(PLANETS.hub.r + 0.6, Math.min(PLANETS.hub.r + 6, d)));
+      }
+      e.m.rotation.x += dt * 3; e.m.rotation.y += dt * 4;
+    }
+    if (performance.now() - lastDup > 1500 && echoes.length < 60) {
+      lastDup = performance.now();
+      spawnEcho(echoes[Math.floor(Math.random() * echoes.length)].m.position.clone());
+    }
+    document.getElementById("echo-n").textContent = echoes.length;
+  }
+  cursed.material.emissiveIntensity = cursed.visible ? 0.4 + 0.3 * Math.sin(performance.now() / 250) : 0;
+
+  // ambience: spinning launch stars, swirling wormholes, billboards facing you
+  for (const s of launchMeshes) s.rotation.y += dt * 2.2;
+  for (const w of wormholes) { w.children[0].rotation.z += dt * 1.6; w.children[1].rotation.z -= dt * 2.4; }
+  for (const b of billboards) b.quaternion.copy(camera.quaternion);
+
+  // HUD
+  document.getElementById("room-label").textContent = "📍 " + player.planet.name + (player.flight ? " → in transit" : "");
+  document.getElementById("room-sub").textContent = player.planet.sub;
+  const near = document.pointerLockElement && !player.flight ? nearestInteractable() : null;
+  promptEl.style.display = near ? "block" : "none";
+  if (near) promptEl.textContent = "[E] " + near.label;
+
+  renderer.render(scene, camera);
+}
+tick();
+
+setTimeout(() => lore(
+  "🌌 Welcome to <b>Mautrix Galaxy</b>. Every planetoid is a Matrix room — standing on one is membership. " +
+  "Pipes between worlds are <b>plumbing</b>; the swirling <b>wormholes</b> are megabridge portals (no pipes allowed); " +
+  "the ghosts are <code>@_relay_*</code> puppets carrying mail through subspace. Start at the registrar's desk, " +
+  "then ride the launch star to the Hub World.", 13000), 800);
+</script>
+</body>
+</html>

--- a/primer/land.html
+++ b/primer/land.html
@@ -169,6 +169,67 @@ function lamp(pos, color = 0xffe0a0, intensity = 30, dist = 30) {
   scene.add(new THREE.Points(g, new THREE.PointsMaterial({ color: 0xb9a5f5, size: 1.1, sizeAttenuation: false, transparent: true, opacity: 0.8 })));
 }
 
+// ---------- nebula skybox ----------
+// A painted sky: vertical depth gradient + soft nebula blooms in the
+// palette of the five platforms. Backside sphere, drawn before everything.
+{
+  const cv = document.createElement("canvas");
+  cv.width = 1024; cv.height = 512;
+  const g = cv.getContext("2d");
+  const grad = g.createLinearGradient(0, 0, 0, 512);
+  grad.addColorStop(0, "#0c0e20");
+  grad.addColorStop(0.45, "#0a0c16");
+  grad.addColorStop(0.78, "#120a20");
+  grad.addColorStop(1, "#06070d");
+  g.fillStyle = grad; g.fillRect(0, 0, 1024, 512);
+  const blobs = [
+    [180, 150, 200, "rgba(106, 79, 196, 0.18)"],   // violet — the deep field
+    [330, 340, 160, "rgba(13, 189, 139, 0.10)"],   // matrix green
+    [700, 120, 230, "rgba(58, 118, 240, 0.14)"],   // signal blue
+    [870, 360, 180, "rgba(232, 184, 75, 0.08)"],   // gold dust
+    [520, 250, 280, "rgba(140, 90, 200, 0.09)"],   // wide violet wash
+    [80, 420, 150, "rgba(37, 211, 102, 0.06)"],    // whatsapp green, faint
+  ];
+  for (const [x, y, r, c] of blobs) {
+    const rg = g.createRadialGradient(x, y, 0, x, y, r);
+    rg.addColorStop(0, c); rg.addColorStop(1, "rgba(0,0,0,0)");
+    g.fillStyle = rg;
+    g.fillRect(x - r, y - r, r * 2, r * 2);
+  }
+  const tex = new THREE.CanvasTexture(cv);
+  tex.colorSpace = THREE.SRGBColorSpace;
+  const sky = new THREE.Mesh(new THREE.SphereGeometry(460, 32, 20),
+    new THREE.MeshBasicMaterial({ map: tex, side: THREE.BackSide, depthWrite: false }));
+  sky.renderOrder = -1;
+  scene.add(sky);
+}
+
+// ---------- particle trails ----------
+// Soft additive puffs left behind by envelopes (their stripe colour) and
+// ghosts (pale wisps). Shrink + fade, then disposed.
+const trailParticles = [];
+const softDot = (() => {
+  const cv = document.createElement("canvas");
+  cv.width = cv.height = 64;
+  const g = cv.getContext("2d");
+  const rg = g.createRadialGradient(32, 32, 0, 32, 32, 32);
+  rg.addColorStop(0, "rgba(255,255,255,1)");
+  rg.addColorStop(0.4, "rgba(255,255,255,0.5)");
+  rg.addColorStop(1, "rgba(255,255,255,0)");
+  g.fillStyle = rg; g.fillRect(0, 0, 64, 64);
+  return new THREE.CanvasTexture(cv);
+})();
+function puff(pos, color, scale = 0.45, life = 0.65) {
+  const m = new THREE.Sprite(new THREE.SpriteMaterial({
+    map: softDot, color, transparent: true, opacity: 0.85,
+    blending: THREE.AdditiveBlending, depthWrite: false,
+  }));
+  m.position.copy(pos);
+  m.scale.setScalar(scale);
+  scene.add(m);
+  trailParticles.push({ m, life, maxLife: life });
+}
+
 // ---------- planetoids (rooms) ----------
 // base/accent = high/low terrain tones · glow = atmosphere rim · flora = decoration set
 const PLANETS = {
@@ -446,7 +507,7 @@ function makeEnvelope(color) {
   return g;
 }
 function postEnvelope(color, path, speed = 7) {
-  envelopes.push({ m: makeEnvelope(color), path, t: 0, seg: 0, speed });
+  envelopes.push({ m: makeEnvelope(color), color, path, t: 0, seg: 0, speed, emit: 0 });
 }
 /** Mail rides a pipe INTO the hub: follow the curve wing→hub, then hop to the table.
     (Pipe curves are built hub→wing, so we walk them reversed.) */
@@ -734,6 +795,9 @@ function tick() {
     e.t += (e.speed * dt) / L;
     if (e.t >= 1) { e.t = 0; e.seg++; } else e.m.position.lerpVectors(a, b, e.t);
     e.m.rotation.y += dt * 2;
+    // comet trail in the envelope's platform colour
+    e.emit = (e.emit || 0) + dt;
+    if (e.emit > 0.06) { e.emit = 0; puff(e.m.position, e.color || 0xffffff); }
   }
 
   // ghosts through subspace
@@ -750,12 +814,29 @@ function tick() {
         gh.env.visible = false;
         const drop = makeEnvelope(gh.color);
         drop.position.copy(gh.g.position);
-        envelopes.push({ m: drop, path: [drop.position.clone(), hubTableTop()], t: 0, seg: 0, speed: 2.5 });
+        envelopes.push({ m: drop, color: gh.color, path: [drop.position.clone(), hubTableTop()], t: 0, seg: 0, speed: 2.5, emit: 0 });
       }
     } else {
       gh.g.position.lerpVectors(a, b, gh.t);
       gh.env.position.copy(gh.g.position).add(v(0, -0.15, 0.3));
+      // squash & stretch (the ghost breathes as it drifts) + face the way it's going
+      const wob = Math.sin(performance.now() / 140 + n * 1.7);
+      gh.g.scale.set(1 - wob * 0.05, 1 + wob * 0.09, 1 - wob * 0.05);
+      gh.g.lookAt(b);
+      gh.g.rotateY(Math.PI);   // eyes sit on +Z; lookAt points -Z at the target
+      // pale wisp trail
+      gh.emit = (gh.emit || 0) + dt;
+      if (gh.emit > 0.12) { gh.emit = 0; puff(gh.g.position, 0xbfc8e8, 0.6, 0.8); }
     }
+  }
+
+  // trail particles: fade + shrink, then dispose
+  for (let n = trailParticles.length - 1; n >= 0; n--) {
+    const p = trailParticles[n];
+    p.life -= dt;
+    if (p.life <= 0) { scene.remove(p.m); p.m.material.dispose(); trailParticles.splice(n, 1); continue; }
+    p.m.material.opacity = 0.85 * (p.life / p.maxLife);
+    p.m.scale.multiplyScalar(1 - dt * 1.1);
   }
 
   // echo storm: bounce inside a shell around the hub world
@@ -798,7 +879,7 @@ tick();
 // Debug/screenshot hook: lets headless verification reposition the view
 // (outside pointer lock the engine copies camera.position from player.pos
 // but leaves orientation alone, so a one-off lookAt sticks).
-window.__galaxy = { player, camera, PLANETS, v };
+window.__galaxy = { player, camera, scene, PLANETS, v };
 
 setTimeout(() => lore(
   "🌌 Welcome to <b>Mautrix Galaxy</b>. Every planetoid is a Matrix room — standing on one is membership. " +

--- a/primer/land.html
+++ b/primer/land.html
@@ -170,28 +170,147 @@ function lamp(pos, color = 0xffe0a0, intensity = 30, dist = 30) {
 }
 
 // ---------- planetoids (rooms) ----------
+// base/accent = high/low terrain tones · glow = atmosphere rim · flora = decoration set
 const PLANETS = {
-  admin:    { c: v(0, 3, 36),     r: 5,   color: 0x3a4054, name: "Admin Planetoid", sub: "#admins · the registrar's desk" },
-  hub:      { c: v(0, 0, 0),      r: 11,  color: 0x35406a, name: "The Hub World", sub: "#superbridge — one world, five galaxies" },
-  discord:  { c: v(-44, 10, -12), r: 7,   color: 0x2c3163, name: "Discord Planetoid", sub: "plumbed · standalone Go bridge" },
-  telegram: { c: v(44, -8, -12),  r: 7,   color: 0x1d3a4d, name: "Telegram Planetoid", sub: "plumbed · bridgev2 — mind the receiver" },
-  whatsapp: { c: v(-38, 34, -86), r: 6.5, color: 0x1d4030, name: "WhatsApp Portal World", sub: "bridge-owned · wormhole-only · doorless" },
-  signal:   { c: v(38, -30, -86), r: 6.5, color: 0x1d2a4d, name: "Signal Portal World", sub: "bridge-owned · wormhole-only · doorless" },
+  admin:    { c: v(0, 3, 36),     r: 5,   base: 0x8d96b4, accent: 0x5a6280, glow: 0xe8b84b, flora: "stone",  seed: 11, name: "Admin Planetoid", sub: "#admins · the registrar's desk" },
+  hub:      { c: v(0, 0, 0),      r: 11,  base: 0x47b06f, accent: 0x7a5b3a, glow: 0x9fd8ff, flora: "meadow", seed: 23, name: "The Hub World", sub: "#superbridge — one world, five galaxies" },
+  discord:  { c: v(-44, 10, -12), r: 7,   base: 0x6a74e8, accent: 0x3c4290, glow: 0x8b97ff, flora: "crystal", seed: 37, name: "Discord Planetoid", sub: "plumbed · standalone Go bridge" },
+  telegram: { c: v(44, -8, -12),  r: 7,   base: 0x4fb6e0, accent: 0x27607e, glow: 0x6fd2f2, flora: "crystal", seed: 41, name: "Telegram Planetoid", sub: "plumbed · bridgev2 — mind the receiver" },
+  whatsapp: { c: v(-38, 34, -86), r: 6.5, base: 0x3fae5f, accent: 0x1d6638, glow: 0x7fe8a8, flora: "jungle", seed: 53, name: "WhatsApp Portal World", sub: "bridge-owned · wormhole-only · doorless" },
+  signal:   { c: v(38, -30, -86), r: 6.5, base: 0x6f93e8, accent: 0x32477e, glow: 0x9ab8ff, flora: "ice",    seed: 67, name: "Signal Portal World", sub: "bridge-owned · wormhole-only · doorless" },
 };
 const mat = c => new THREE.MeshLambertMaterial({ color: c });
+
+// --- deterministic terrain noise -------------------------------------
+// Layered trig noise: a pure function of surface DIRECTION, so the mesh,
+// the props, and the player's feet all agree on where the ground is.
+function mulberry32(seed) {
+  return () => {
+    seed |= 0; seed = seed + 0x6D2B79F5 | 0;
+    let t = Math.imul(seed ^ seed >>> 15, 1 | seed);
+    t = t + Math.imul(t ^ t >>> 7, 61 | t) ^ t;
+    return ((t ^ t >>> 14) >>> 0) / 4294967296;
+  };
+}
 for (const p of Object.values(PLANETS)) {
-  const m = new THREE.Mesh(new THREE.SphereGeometry(p.r, 36, 24), mat(p.color));
+  const rng = mulberry32(p.seed);
+  const waves = [];
+  for (let k = 0; k < 5; k++) {
+    const u = v(rng() * 2 - 1, rng() * 2 - 1, rng() * 2 - 1).normalize();
+    waves.push({ u, f: 2 + rng() * 4.5, ph: rng() * Math.PI * 2, w: 1 / (k * 0.6 + 1) });
+  }
+  const wsum = waves.reduce((s, w) => s + w.w, 0);
+  p.noise = dir => waves.reduce((s, w) => s + Math.sin(dir.dot(w.u) * w.f * Math.PI + w.ph) * w.w, 0) / wsum;
+  p.amp = p.r * 0.085;
+  p.rng = rng;
+}
+/** Ground radius (from planet centre) under a given surface direction. */
+const terrain = (p, dir) => p.r + p.amp * p.noise(dir.clone().normalize());
+const surfacePoint = (p, dir, h = 0) =>
+  p.c.clone().addScaledVector(dir.clone().normalize(), terrain(p, dir) + h);
+
+// --- build each world: lumpy flat-shaded mesh + atmosphere + flora ----
+const _tmpDir = new THREE.Vector3();
+for (const p of Object.values(PLANETS)) {
+  const geo = new THREE.IcosahedronGeometry(p.r, 5);
+  const pos = geo.attributes.position;
+  const colors = new Float32Array(pos.count * 3);
+  const cBase = new THREE.Color(p.base), cAcc = new THREE.Color(p.accent), cTmp = new THREE.Color();
+  for (let i = 0; i < pos.count; i++) {
+    _tmpDir.fromBufferAttribute(pos, i).normalize();
+    const n = p.noise(_tmpDir);                       // [-1, 1]
+    _tmpDir.multiplyScalar(p.r + p.amp * n);
+    pos.setXYZ(i, _tmpDir.x, _tmpDir.y, _tmpDir.z);
+    // low ground → accent (dirt/depths), high ground → base (grass/peaks)
+    const t = Math.min(1, Math.max(0, n * 0.5 + 0.5));
+    cTmp.lerpColors(cAcc, cBase, t * t * (3 - 2 * t));
+    colors.set([cTmp.r, cTmp.g, cTmp.b], i * 3);
+  }
+  geo.setAttribute("color", new THREE.BufferAttribute(colors, 3));
+  geo.computeVertexNormals();
+  const m = new THREE.Mesh(geo, new THREE.MeshStandardMaterial({
+    vertexColors: true, flatShading: true, roughness: 0.95, metalness: 0.0,
+  }));
   m.position.copy(p.c);
   scene.add(m);
-  // a few craters/rocks for texture
-  for (let i = 0; i < 7; i++) {
-    const d = v(Math.random() - 0.5, Math.random() - 0.5, Math.random() - 0.5).normalize();
-    const rock = new THREE.Mesh(new THREE.DodecahedronGeometry(0.3 + Math.random() * 0.5), mat(C.rock2));
-    rock.position.copy(p.c).addScaledVector(d, p.r - 0.1);
-    scene.add(rock);
+
+  // atmosphere: a soft additive rim, Mario Galaxy's halo
+  const halo = new THREE.Mesh(new THREE.SphereGeometry(p.r * 1.16, 28, 18),
+    new THREE.MeshBasicMaterial({ color: p.glow, transparent: true, opacity: 0.13,
+      side: THREE.BackSide, blending: THREE.AdditiveBlending, depthWrite: false }));
+  halo.position.copy(p.c);
+  scene.add(halo);
+}
+
+// --- flora & props, scattered deterministically per world -------------
+function prop(p, dir, mesh, lift = 0) {
+  const n = dir.clone().normalize();
+  mesh.position.copy(surfacePoint(p, n, lift));
+  mesh.quaternion.setFromUnitVectors(v(0, 1, 0), n);
+  // random spin around local up so rows of props don't all face one way
+  mesh.rotateY(p.rng() * Math.PI * 2);
+  scene.add(mesh);
+  return mesh;
+}
+const FLORA = {
+  meadow(p, dir) {
+    const pick = p.rng();
+    if (pick < 0.45) {  // beacon tower — the hub relays for five galaxies
+      const g = new THREE.Group();
+      g.add(new THREE.Mesh(new THREE.CylinderGeometry(0.09, 0.16, 1.6, 6), mat(0x8b91a5)));
+      const tip = new THREE.Mesh(new THREE.SphereGeometry(0.16, 8, 8),
+        new THREE.MeshLambertMaterial({ color: 0xffe89c, emissive: 0xe8b84b, emissiveIntensity: 0.8 }));
+      tip.position.y = 0.9; g.add(tip);
+      return prop(p, dir, g, 0.7);
+    }
+    const tuft = new THREE.Mesh(new THREE.ConeGeometry(0.22, 0.55, 5),
+      new THREE.MeshLambertMaterial({ color: pick < 0.75 ? 0x5fd488 : 0xe8b84b }));
+    return prop(p, dir, tuft, 0.25);
+  },
+  jungle(p, dir) {
+    const g = new THREE.Group();
+    g.add(new THREE.Mesh(new THREE.CylinderGeometry(0.12, 0.18, 0.9, 6), mat(0x5a4026)));
+    const layers = 2 + Math.floor(p.rng() * 2);
+    for (let i = 0; i < layers; i++) {
+      const leaf = new THREE.Mesh(new THREE.ConeGeometry(0.75 - i * 0.2, 0.7, 7), mat(0x2fae5f));
+      leaf.position.y = 0.65 + i * 0.45;
+      g.add(leaf);
+    }
+    return prop(p, dir, g, 0.45);
+  },
+  ice(p, dir) {
+    const h = 0.6 + p.rng() * 1.3;
+    const shard = new THREE.Mesh(new THREE.ConeGeometry(0.18 + p.rng() * 0.16, h, 5),
+      new THREE.MeshLambertMaterial({ color: 0x9ab8ff, emissive: 0x3a76f0, emissiveIntensity: 0.35,
+        transparent: true, opacity: 0.9 }));
+    shard.rotation.x = (p.rng() - 0.5) * 0.5;
+    return prop(p, dir, shard, h * 0.4);
+  },
+  crystal(p, dir) {
+    const h = 0.5 + p.rng() * 1.1;
+    const c = p === PLANETS.discord ? 0x8b97ff : 0x6fd2f2;
+    const shard = new THREE.Mesh(new THREE.OctahedronGeometry(0.28 + p.rng() * 0.2),
+      new THREE.MeshLambertMaterial({ color: c, emissive: c, emissiveIntensity: 0.45 }));
+    shard.scale.y = 1.6 + p.rng();
+    return prop(p, dir, shard, h * 0.35);
+  },
+  stone(p, dir) {
+    const rock = new THREE.Mesh(new THREE.DodecahedronGeometry(0.25 + p.rng() * 0.45), mat(C.rock2));
+    return prop(p, dir, rock, 0.1);
+  },
+};
+for (const p of Object.values(PLANETS)) {
+  const count = Math.round(p.r * 3.4);
+  for (let i = 0; i < count; i++) {
+    const dir = v(p.rng() * 2 - 1, p.rng() * 2 - 1, p.rng() * 2 - 1);
+    if (dir.lengthSq() < 0.05) continue;
+    dir.normalize();
+    if (dir.dot(v(0, 1, 0)) > 0.86) continue;   // keep the polar landmark areas clear
+    FLORA[p.flora](p, dir);
+    // every world also gets a few plain rocks for grit
+    if (i % 5 === 0) FLORA.stone(p, v(p.rng() * 2 - 1, p.rng() * 2 - 1, p.rng() * 2 - 1).normalize());
   }
 }
-const surfacePoint = (p, dir, h = 0) => p.c.clone().addScaledVector(dir.clone().normalize(), p.r + h);
 
 /** Stand `obj` on a planet surface: position at dir, +Y aligned to the normal. */
 function placeOnPlanet(obj, p, dir, h = 0) {
@@ -203,7 +322,8 @@ function placeOnPlanet(obj, p, dir, h = 0) {
 }
 function boxOnPlanet(w, hgt, d, color, p, dir, lift = 0) {
   const m = new THREE.Mesh(new THREE.BoxGeometry(w, hgt, d), mat(color));
-  return placeOnPlanet(m, p, dir, hgt / 2 + lift);
+  // seat 0.2 into the ground so edges don't float on sloped terrain
+  return placeOnPlanet(m, p, dir, hgt / 2 + lift - 0.2);
 }
 
 // ---------- signage (billboards — always face the player) ----------
@@ -571,12 +691,12 @@ function updatePlayer(dt) {
   if (keys.KeyA) dir.sub(right);
   if (dir.lengthSq()) player.pos.addScaledVector(dir.normalize(), 5.6 * dt);
 
-  // radial gravity: fall toward the planet's heart
+  // radial gravity: fall toward the planet's heart, land on the rolling terrain
   player.vy -= 13 * dt;
   let h = player.pos.distanceTo(P.c) + player.vy * dt;
-  const minH = P.r + 1.7;
-  if (h <= minH) { h = minH; player.vy = 0; player.grounded = true; }
   up = player.pos.clone().sub(P.c).normalize();
+  const minH = terrain(P, up) + 1.7;   // ground height under our feet, not the nominal radius
+  if (h <= minH) { h = minH; player.vy = 0; player.grounded = true; }
   player.pos.copy(P.c).addScaledVector(up, h);
 
   camera.position.copy(player.pos);
@@ -644,9 +764,10 @@ function tick() {
       e.m.position.addScaledVector(e.vel, dt);
       const rel = e.m.position.clone().sub(PLANETS.hub.c);
       const d = rel.length(), nrm = rel.normalize();
-      if (d < PLANETS.hub.r + 0.6 || d > PLANETS.hub.r + 6) {
+      const lo = PLANETS.hub.r + PLANETS.hub.amp + 0.6, hi = PLANETS.hub.r + 6;
+      if (d < lo || d > hi) {
         e.vel.addScaledVector(nrm, -2 * e.vel.dot(nrm));
-        e.m.position.copy(PLANETS.hub.c).addScaledVector(nrm, Math.max(PLANETS.hub.r + 0.6, Math.min(PLANETS.hub.r + 6, d)));
+        e.m.position.copy(PLANETS.hub.c).addScaledVector(nrm, Math.max(lo, Math.min(hi, d)));
       }
       e.m.rotation.x += dt * 3; e.m.rotation.y += dt * 4;
     }
@@ -673,6 +794,11 @@ function tick() {
   renderer.render(scene, camera);
 }
 tick();
+
+// Debug/screenshot hook: lets headless verification reposition the view
+// (outside pointer lock the engine copies camera.position from player.pos
+// but leaves orientation alone, so a one-off lookAt sticks).
+window.__galaxy = { player, camera, PLANETS, v };
 
 setTimeout(() => lore(
   "🌌 Welcome to <b>Mautrix Galaxy</b>. Every planetoid is a Matrix room — standing on one is membership. " +

--- a/primer/mic-worklet.js
+++ b/primer/mic-worklet.js
@@ -1,0 +1,21 @@
+// AudioWorklet processor: mic float32 → PCM16 frames posted to the main
+// thread, which base64s them into input_audio_buffer.append events.
+// Same pattern as embodied-dreamfinder/mic-worklet.js.
+class MicProcessor extends AudioWorkletProcessor {
+  process(inputs) {
+    const input = inputs[0];
+    if (!input || !input[0] || input[0].length === 0) return true;
+
+    const float32 = input[0];
+    const pcm16 = new Int16Array(float32.length);
+    for (let i = 0; i < float32.length; i++) {
+      const s = Math.max(-1, Math.min(1, float32[i]));
+      pcm16[i] = s < 0 ? s * 0x8000 : s * 0x7fff;
+    }
+
+    this.port.postMessage(pcm16.buffer, [pcm16.buffer]);
+    return true;
+  }
+}
+
+registerProcessor("mic-processor", MicProcessor);

--- a/primer/server.mjs
+++ b/primer/server.mjs
@@ -148,6 +148,8 @@ const server = http.createServer(async (req, res) => {
       "/": ["index.html", "text/html"],
       "/index.html": ["index.html", "text/html"],
       "/mic-worklet.js": ["mic-worklet.js", "text/javascript"],
+      "/land": ["land.html", "text/html"],
+      "/land.html": ["land.html", "text/html"],
     };
     if (req.method === "GET" && STATIC[req.url]) {
       const [file, type] = STATIC[req.url];

--- a/primer/server.mjs
+++ b/primer/server.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+/**
+ * The Bridgekeeper's Primer — adaptive backend.
+ *
+ * Serves the game (index.html) and gives it a live tutor ("the ractor"):
+ * every /api/* call shells out to headless Claude Code (`claude -p`), which
+ * runs on the Max subscription, with read-only repo tools and web search
+ * enabled — so the Primer can grep relay/appservice/ and search the mautrix
+ * docs while the learner plays.
+ *
+ * Zero npm dependencies. Binds to localhost only.
+ *
+ *   node primer/server.mjs        # then open http://127.0.0.1:7777
+ */
+import http from "node:http";
+import { spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+const PORT = process.env.PRIMER_PORT || 7777;
+
+// Read-only tools: the Primer may search the repo and the web, never edit.
+const ALLOWED_TOOLS = "Read,Grep,Glob,WebSearch,WebFetch";
+
+/** Run `claude -p` headless and resolve with its stdout text. */
+function askClaude(prompt, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      "claude",
+      ["-p", prompt, "--output-format", "text", "--allowedTools", ALLOWED_TOOLS],
+      { cwd: REPO_ROOT, env: process.env }
+    );
+    let out = "", err = "";
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      reject(new Error("The Primer took too long to think."));
+    }, timeoutMs);
+    child.stdout.on("data", d => (out += d));
+    child.stderr.on("data", d => (err += d));
+    child.on("close", code => {
+      clearTimeout(timer);
+      if (code === 0) resolve(out.trim());
+      else reject(new Error(err.trim() || `claude exited ${code}`));
+    });
+    child.on("error", e => { clearTimeout(timer); reject(e); });
+  });
+}
+
+const PRIMER_VOICE = `You are "The Primer" — the narrator-tutor of an interactive game teaching
+how the imagineering.cc Matrix superbridge works: plumbing vs portal rooms, the mautrix
+bridgev2 "megabridge" framework, split portals and receivers, the relay appservice with
+puppet users, loop prevention, appservice registration on Continuwuity, double puppeting.
+Voice: warm, slightly mythic, precise — Diamond Age's Illustrated Primer crossed with a
+senior infrastructure engineer. Never condescending.
+
+Ground every claim in THIS repository before asserting it: consult CLAUDE.md,
+superbridge.sh, relay/appservice/*.py (handler.py, puppet.py, loop_prevention.py,
+event_map.py, config.py) with the Read/Grep tools. Use WebSearch/WebFetch for current
+mautrix documentation (docs.mau.fi) when the repo alone cannot answer.`;
+
+/** Free-form question asked mid-game. Returns HTML for a chat bubble. */
+async function handleAsk(body) {
+  const prompt = `${PRIMER_VOICE}
+
+The learner pauses the game to ask you a question. Current chapter: ${body.chapter || "unknown"}.
+Their record so far (mistakes made, hints used, earlier questions): ${JSON.stringify(body.learner || {})}
+
+Their question: """${body.question}"""
+
+Research as needed (repo first, web second), then answer in the Primer's voice.
+Reply with 1-3 short paragraphs of plain HTML — only <b>, <i>, <code>, <br> tags,
+no markdown, no headings, no surrounding quotes. Cite file paths in <code> when you
+ground an answer in the repo.`;
+  return { html: await askClaude(prompt, 150_000) };
+}
+
+/** Generate a new adaptive chapter as a JSON scene the engine can run. */
+async function handleChapter(body) {
+  const prompt = `${PRIMER_VOICE}
+
+The learner finished the scripted arc (chapters: ${JSON.stringify(body.completed || [])}).
+Their record — use it to adapt difficulty and to revisit weak spots:
+${JSON.stringify(body.learner || {})}
+
+Requested topic for the next chapter: ${body.topic ? `"""${body.topic}"""` : "(none — you choose, favouring their weak spots or a natural next lesson, e.g. double puppeting, the event_map reply threading, the appservice registration namespace, media relay, or federation)"}
+
+Research the topic in the repo (and web if needed), then write the chapter as a game
+scene. Output ONLY a JSON array — no prose, no markdown fences. Each element is one step:
+
+  {"t":"chapter","title":"Chapter VII · <name>"}
+  {"t":"room","name":"#room:imagineering.cc","desc":"— scene-setting"}
+  {"t":"msg","platform":"primer|matrix|discord|telegram|whatsapp|signal|error|you","sender":"Name","text":"HTML with <b>/<i>/<code> only","ms":900}
+  {"t":"choice","prompt":"question?","options":[{"label":"...","ok":true,"fb":"why right"},{"label":"...","ok":false,"fb":"why wrong"}]}
+  {"t":"multi","prompt":"select all...","applyLabel":"Apply","options":[{"label":"...","ok":true,"why":"..."},...]}
+  {"t":"input","prompt":"type the command...","pattern":"^!tg\\\\s+set-relay$","hint":"...","placeholder":"..."}
+  {"t":"badge","name":"<new badge name>"}
+
+Rules: 12-25 steps. Open with a "chapter" step, end with a "badge" step. Include 1-2
+"choice" puzzles with real technical trade-offs, at most one forgiving "input" regex
+(case-insensitive is applied for you). Teach something TRUE — verify details against the
+repo before asserting them. Wrong-answer feedback must explain the real reason.`;
+  const raw = await askClaude(prompt, 240_000);
+  // Extract the outermost JSON array (the model may add stray text despite instructions).
+  const start = raw.indexOf("["), end = raw.lastIndexOf("]");
+  if (start === -1 || end <= start) throw new Error("Primer returned no scene JSON.");
+  const steps = JSON.parse(raw.slice(start, end + 1));
+  if (!Array.isArray(steps) || !steps.length) throw new Error("Primer returned an empty scene.");
+  return { steps };
+}
+
+// ---- tiny HTTP layer --------------------------------------------------------
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    req.on("data", c => { data += c; if (data.length > 1e6) req.destroy(); });
+    req.on("end", () => { try { resolve(data ? JSON.parse(data) : {}); } catch (e) { reject(e); } });
+  });
+}
+
+const server = http.createServer(async (req, res) => {
+  const send = (code, obj, type = "application/json") => {
+    res.writeHead(code, { "Content-Type": type });
+    res.end(type === "application/json" ? JSON.stringify(obj) : obj);
+  };
+  try {
+    if (req.method === "GET" && (req.url === "/" || req.url === "/index.html"))
+      return send(200, readFileSync(join(__dirname, "index.html")), "text/html");
+    if (req.method === "GET" && req.url === "/api/health")
+      return send(200, { ok: true });
+    if (req.method === "POST" && req.url === "/api/ask")
+      return send(200, await handleAsk(await readBody(req)));
+    if (req.method === "POST" && req.url === "/api/chapter")
+      return send(200, await handleChapter(await readBody(req)));
+    send(404, { error: "not found" });
+  } catch (e) {
+    send(500, { error: e.message });
+  }
+});
+
+server.listen(PORT, "127.0.0.1", () =>
+  console.log(`⛩ The Bridgekeeper's Primer → http://127.0.0.1:${PORT}`)
+);

--- a/primer/server.mjs
+++ b/primer/server.mjs
@@ -22,6 +22,23 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(__dirname, "..");
 const PORT = process.env.PRIMER_PORT || 7777;
 
+/**
+ * Find an env var: process env first, then primer/.env, then the sibling
+ * embodied-dreamfinder repo's .env (same machine, same OpenAI account) so the
+ * voice ractor works without duplicating keys.
+ */
+function loadEnvKey(name) {
+  if (process.env[name]) return process.env[name];
+  for (const p of [join(__dirname, ".env"), join(REPO_ROOT, "..", "embodied-dreamfinder", ".env")]) {
+    try {
+      const m = readFileSync(p, "utf8").match(new RegExp(`^${name}=(.*)$`, "m"));
+      if (m) return m[1].trim().replace(/^["']|["']$/g, "");
+    } catch { /* file absent — keep looking */ }
+  }
+  return "";
+}
+const OPENAI_API_KEY = loadEnvKey("OPENAI_API_KEY");
+
 // Read-only tools: the Primer may search the repo and the web, never edit.
 const ALLOWED_TOOLS = "Read,Grep,Glob,WebSearch,WebFetch";
 
@@ -126,10 +143,30 @@ const server = http.createServer(async (req, res) => {
     res.end(type === "application/json" ? JSON.stringify(obj) : obj);
   };
   try {
-    if (req.method === "GET" && (req.url === "/" || req.url === "/index.html"))
-      return send(200, readFileSync(join(__dirname, "index.html")), "text/html");
+    // Static files — explicit whitelist, no path traversal possible.
+    const STATIC = {
+      "/": ["index.html", "text/html"],
+      "/index.html": ["index.html", "text/html"],
+      "/mic-worklet.js": ["mic-worklet.js", "text/javascript"],
+    };
+    if (req.method === "GET" && STATIC[req.url]) {
+      const [file, type] = STATIC[req.url];
+      return send(200, readFileSync(join(__dirname, file)), type);
+    }
     if (req.method === "GET" && req.url === "/api/health")
-      return send(200, { ok: true });
+      return send(200, { ok: true, voice: Boolean(OPENAI_API_KEY) });
+    // Ephemeral OpenAI Realtime client secret for the voice ractor.
+    // Same flow as embodied-dreamfinder: browser never sees the real key.
+    if (req.method === "GET" && req.url === "/api/token") {
+      if (!OPENAI_API_KEY)
+        return send(503, { error: "OPENAI_API_KEY not configured — voice ractor unavailable" });
+      const r = await fetch("https://api.openai.com/v1/realtime/client_secrets", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${OPENAI_API_KEY}`, "Content-Type": "application/json" },
+        body: "{}",
+      });
+      return send(r.status, await r.json());
+    }
     if (req.method === "POST" && req.url === "/api/ask")
       return send(200, await handleAsk(await readBody(req)));
     if (req.method === "POST" && req.url === "/api/chapter")


### PR DESCRIPTION
## What

The Bridgekeeper's Primer: a chat-shaped teaching game about how the superbridge works (plumbing vs portal rooms, bridgev2 megabridge, receiver locks, the relay appservice, loop prevention). Every puzzle re-enacts a real gotcha from this repo's history.

- `primer/index.html` — single-file game: chat UI, step engine, learner model, ractor hooks
- `primer/land.html` — Mautrix Galaxy: spherical-gravity 3D companion world (three.js)
- `primer/server.mjs` — optional local backend: live tutor via headless Claude Code + voice ractor via OpenAI Realtime
- `primer/mic-worklet.js` — mic capture worklet for the voice ractor

## Published

Static build is live at https://primer.imagineering.cc (and /land) — degraded mode, full six-chapter scripted arc. The adaptive ractor needs a local Claude Code login, so it stays local-only. Caddy route + deploy target shipped in imagineering-infra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)