### PR TITLE
revert: primer was unpublished — drop public-URL docs

### DIFF
--- a/primer/README.md
+++ b/primer/README.md
@@ -8,14 +8,7 @@ repo's history.
 Inspired by the Young Lady's Illustrated Primer (Diamond Age): a scripted arc
 with a live tutor — "the ractor" — behind it.
 
-## Play it
-
-The static build is published at **https://primer.imagineering.cc** (and the
-Mautrix Galaxy at https://primer.imagineering.cc/land). That's degraded mode —
-see below — because the adaptive ractor needs a local Claude Code login.
-Deployed via `imagineering-infra`: `./scripts/deploy-to.sh <ip> primer`.
-
-## Run it (full, with the live ractor)
+## Run it
 
 ```bash
 node primer/server.mjs

--- a/primer/index.html
+++ b/primer/index.html
@@ -290,7 +290,7 @@
 <header>
   <h1>⛩ The Bridgekeeper's Primer</h1>
   <span class="subtitle">A Young Imagineer's Illustrated Guide to the Superbridge</span>
-  <a href="land.html" style="font-size:0.74rem; color:#b9a5f5; text-decoration:none; border:1px solid #6a4fc4; border-radius:999px; padding:5px 14px;">🌌 Mautrix Galaxy</a>
+  <a href="/land" style="font-size:0.74rem; color:#b9a5f5; text-decoration:none; border:1px solid #6a4fc4; border-radius:999px; padding:5px 14px;">🌌 Mautrix Galaxy</a>
   <button id="ractor-btn">🎭 Summon the Ractor</button>
   <div id="badges"></div>
 </header>


### PR DESCRIPTION
Reverts the static-publish readiness commit: primer.imagineering.cc has been taken down (infra PR imagineering-cc/imagineering-infra#72), so the README's public-URL section was wrong. Restores the `/land` link used by the local server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)